### PR TITLE
Updated Get Source Control Connector Configuration playbook jinja

### DIFF
--- a/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
+++ b/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
@@ -30,7 +30,7 @@
             },
             "status": null,
             "top": "165",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "85cba27a-af44-4e37-a0c9-9fddf9598f16"
@@ -42,11 +42,11 @@
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
                 "repo_name": "{{vars.cicd_config.content.split('\/')[-1]}}",
-                "assigneeUsername": "{{vars.input.params.assignee.sourceControlUsername}}"
+                "assigneeUsername": "{{vars.USER_MAPPING.get(vars.steps.Get_Change_Request_Details.input.assignee)}}"
             },
             "status": null,
-            "top": "435",
-            "left": "310",
+            "top": "705",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "20429145-4b50-4df0-a0c8-cde5d66ccd7e"
@@ -68,8 +68,8 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateBranch\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1110",
-            "left": "135",
+            "top": "975",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "ef404be3-62aa-4dac-8a59-e8caa1db9eb7"
@@ -81,7 +81,7 @@
             "arguments": {
                 "arguments": {
                     "connector_config_id": "{{vars.cicd_env[\"source_control\"][\"uuid\"]}}",
-                    "create_issue_params": "{\"org_name\": \"{{vars.cicd_config.organizationName}}\",\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\"issue_title\": \"{{vars.input.params.summary}}\/{{uuid()}}\",\"issue_content\": \"{{vars.input.params.description}}\",\"issue_assignee\": \"{{[vars.assigneeUsername]}}\"}"
+                    "create_issue_params": "{\"org_name\": \"{{vars.cicd_config.organizationName}}\",\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\"issue_title\": \"{{vars.steps.Get_Change_Request_Details.input.summary}}\/{{uuid()}}\",\"issue_content\": \"{{vars.steps.Get_Change_Request_Details.input.description}}\",\"issue_assignee\": \"{{[vars.assigneeUsername]}}\"}"
                 },
                 "apply_async": false,
                 "step_variables": [],
@@ -90,11 +90,128 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateIssue\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "975",
-            "left": "135",
+            "top": "840",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "142799f7-839a-4e01-b9a1-962a8d7a826d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Change Request Details",
+            "description": null,
+            "arguments": {
+                "type": "InputBased",
+                "input": {
+                    "schema": {
+                        "title": "Create New Request",
+                        "description": "Creates a new change request (issue) on {{vars.cicd_config.contentRepoName}} repository.",
+                        "inputVariables": [
+                            {
+                                "name": "summary",
+                                "type": "string",
+                                "label": "Summary",
+                                "tooltip": "Provide the Summary of Change Request",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": true,
+                                "defaultValue": null,
+                                "_previousName": "",
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "description",
+                                "type": "string",
+                                "label": "Description",
+                                "title": "Rich Text (HTML)",
+                                "usable": true,
+                                "tooltip": "Provide the Description of Change Request",
+                                "dataType": "text",
+                                "formType": "html",
+                                "required": true,
+                                "_expanded": true,
+                                "mmdUpdate": true,
+                                "collection": false,
+                                "searchable": true,
+                                "templateUrl": "app\/components\/form\/fields\/htmlEditor.html",
+                                "defaultValue": "",
+                                "_previousName": "description",
+                                "playbookField": true,
+                                "lengthConstraint": true,
+                                "allowedEncryption": true,
+                                "allowedGridColumn": true,
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "assignee",
+                                "type": "array",
+                                "label": "Assignee",
+                                "title": "Dynamic List",
+                                "usable": true,
+                                "options": "{{vars.user_list}}",
+                                "tooltip": "Select the Change Request Assignee Username",
+                                "dataType": "dynamicList",
+                                "formType": "dynamicList",
+                                "required": true,
+                                "_expanded": true,
+                                "mmdUpdate": true,
+                                "collection": false,
+                                "searchable": false,
+                                "templateUrl": "app\/components\/form\/fields\/dynamicList.html",
+                                "defaultValue": null,
+                                "_previousName": "assignee",
+                                "playbookField": true,
+                                "lengthConstraint": true,
+                                "allowedGridColumn": false,
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            }
+                        ]
+                    }
+                },
+                "record": "",
+                "agent_id": null,
+                "resources": "change_management",
+                "is_approval": false,
+                "owner_detail": {
+                    "isAssigned": false,
+                    "emailRecipients": ""
+                },
+                "isRecordLinked": false,
+                "step_variables": [],
+                "response_mapping": {
+                    "options": [
+                        {
+                            "option": "Submit",
+                            "primary": true,
+                            "step_iri": "\/api\/3\/workflow_steps\/20429145-4b50-4df0-a0c8-cde5d66ccd7e"
+                        }
+                    ],
+                    "duplicateOption": false,
+                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
+                },
+                "email_notification": {
+                    "enabled": false,
+                    "smtpParameters": []
+                },
+                "customEmailExternal": false,
+                "inline_channel_list": [],
+                "external_channel_list": [],
+                "unauthenticated_input": false,
+                "external_email_subject": null,
+                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
+                "custom_email_body_external": null,
+                "external_email_attachments": null
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+            "group": null,
+            "uuid": "f87d6e93-7ed0-4a73-b3a8-0dba10b70241"
         },
         {
             "@type": "WorkflowStep",
@@ -117,166 +234,36 @@
             },
             "status": null,
             "top": "300",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "aa6d9b92-8a27-463a-94d0-63c28fef2630"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Is Username Available",
+            "name": "Get Users",
             "description": null,
             "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/d47decc2-caa4-465f-918b-1575b94110f7",
-                        "condition": "{{ vars.assigneeUsername != None }}",
-                        "step_name": "Placeholder"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/c531f160-58b9-443b-9d8a-90557b64fc53",
-                        "step_name": "Refresh User Version Control Details"
-                    }
-                ]
-            },
-            "status": null,
-            "top": "570",
-            "left": "310",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "14ab3b78-7479-4cf2-9aef-e507664407c6"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is Username Exist",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/142799f7-839a-4e01-b9a1-962a8d7a826d",
-                        "condition": "{{ vars.assigneeUsername | length > 0 }}",
-                        "step_name": "Create Issue"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/f9ff1afb-9ed5-42d9-bd79-24b1d53fa483",
-                        "step_name": "Source Control User Not Mapped"
-                    }
-                ],
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "485",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "b69c479a-284f-45c8-bc02-ca0c258e44d7"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "No Operation",
-            "description": null,
-            "arguments": {
-                "params": [],
-                "version": "3.2.3",
+                "params": {
+                    "iri": "\/api\/3\/people",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.2.6",
                 "connector": "cyops_utilities",
-                "operation": "no_op",
-                "operationTitle": "Utils: No Operation",
-                "step_variables": []
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "user_list": "{% set user_list = [] %}{% for user in vars.steps.Get_Users.data['hydra:member'] %}{% if user['sourceControlUsername'] != None %}{% set _=user_list.append(user.firstname + \" \"+ user.lastname) %}{% endif %}{% endfor %}{{user_list}}",
+                    "USER_MAPPING": "{% set user_mapping = {} %}{% for user in vars.steps.Get_Users.data['hydra:member'] %}{% if user['sourceControlUsername'] != None %}{% set _=user_mapping.update({user.firstname + \" \"+ user.lastname : user.sourceControlUsername }) %}{% endif %}{% endfor %}{{user_mapping}}"
+                }
             },
             "status": null,
-            "top": "1110",
-            "left": "495",
+            "top": "435",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
-            "uuid": "63f36a6a-2cbc-4cab-a2d2-7ed00519fef8"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Placeholder",
-            "description": null,
-            "arguments": {
-                "_temp": "_temp"
-            },
-            "status": null,
-            "top": "840",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "d47decc2-caa4-465f-918b-1575b94110f7"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Refresh User Version Control Details",
-            "description": null,
-            "arguments": {
-                "assigneeUsername": "{{(vars.input.params.assignee['@id'] | fromIRI).sourceControlUsername}}"
-            },
-            "status": null,
-            "top": "705",
-            "left": "485",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "c531f160-58b9-443b-9d8a-90557b64fc53"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Source Control User Not Mapped",
-            "description": null,
-            "arguments": {
-                "type": "InputBased",
-                "input": {
-                    "schema": {
-                        "title": "Map Source Control Username",
-                        "description": "Source Control username is not mapped for assigned Change Request username \"{{vars.input.params.assignee.firstname}} {{vars.input.params.assignee.lastname}}\".\nFirst \"Map Source Control Username\" before creating the \"Change Request\"",
-                        "inputVariables": []
-                    }
-                },
-                "record": "",
-                "agent_id": null,
-                "resources": "change_management",
-                "is_approval": false,
-                "owner_detail": {
-                    "isAssigned": false,
-                    "emailRecipients": ""
-                },
-                "isRecordLinked": false,
-                "step_variables": [],
-                "response_mapping": {
-                    "options": [
-                        {
-                            "option": "Ok",
-                            "primary": true,
-                            "step_iri": "\/api\/3\/workflow_steps\/63f36a6a-2cbc-4cab-a2d2-7ed00519fef8"
-                        }
-                    ],
-                    "duplicateOption": false,
-                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
-                },
-                "email_notification": {
-                    "enabled": false,
-                    "smtpParameters": []
-                },
-                "customEmailExternal": false,
-                "inline_channel_list": [],
-                "external_channel_list": [],
-                "unauthenticated_input": false,
-                "external_email_subject": null,
-                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
-                "custom_email_body_external": null,
-                "external_email_attachments": null
-            },
-            "status": null,
-            "top": "975",
-            "left": "495",
-            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
-            "group": null,
-            "uuid": "f9ff1afb-9ed5-42d9-bd79-24b1d53fa483"
+            "uuid": "902690e1-0853-48a8-8244-a10801612e20"
         },
         {
             "@type": "WorkflowStep",
@@ -288,99 +275,28 @@
                 "resources": [
                     "change_management"
                 ],
-                "inputVariables": [
-                    {
-                        "name": "summary",
-                        "type": "string",
-                        "label": "Summary",
-                        "title": "Text Field",
-                        "usable": true,
-                        "tooltip": "Provide the Summary of Change Request",
-                        "dataType": "text",
-                        "formType": "text",
-                        "required": true,
-                        "_expanded": false,
-                        "mmdUpdate": true,
-                        "collection": false,
-                        "searchable": true,
-                        "templateUrl": "app\/components\/form\/fields\/input.html",
-                        "defaultValue": null,
-                        "_previousName": "summary",
-                        "playbookField": true,
-                        "lengthConstraint": true,
-                        "allowedEncryption": true,
-                        "allowedGridColumn": true,
-                        "useRecordFieldDefault": false
-                    },
-                    {
-                        "name": "description",
-                        "type": "string",
-                        "label": "Description",
-                        "title": "Rich Text (HTML)",
-                        "usable": true,
-                        "tooltip": "Provide the Description of Change Request",
-                        "dataType": "text",
-                        "formType": "html",
-                        "required": true,
-                        "_expanded": false,
-                        "mmdUpdate": true,
-                        "collection": false,
-                        "searchable": true,
-                        "templateUrl": "app\/components\/form\/fields\/htmlEditor.html",
-                        "defaultValue": "",
-                        "_previousName": "description",
-                        "playbookField": true,
-                        "lengthConstraint": true,
-                        "allowedEncryption": true,
-                        "allowedGridColumn": true,
-                        "useRecordFieldDefault": false
-                    },
-                    {
-                        "name": "assignee",
-                        "type": "people",
-                        "label": "Assignee",
-                        "title": "Lookup (One to Many or One to One)",
-                        "usable": true,
-                        "tooltip": "Select the Change Request Assignee Username",
-                        "dataType": "lookup",
-                        "formType": "lookup",
-                        "required": true,
-                        "_expanded": false,
-                        "mmdUpdate": true,
-                        "collection": false,
-                        "dataSource": {
-                            "model": "people"
-                        },
-                        "searchable": false,
-                        "templateUrl": "app\/components\/form\/fields\/typeahead.html",
-                        "defaultValue": null,
-                        "_previousName": "",
-                        "playbookField": true,
-                        "displayTemplate": "%7B%7B%20firstname%20%7D%7D%20%7B%7B%20lastname%20%7D%7D",
-                        "lengthConstraint": false,
-                        "allowedEncryption": false,
-                        "allowedGridColumn": true,
-                        "useRecordFieldDefault": false
-                    }
-                ],
+                "__triggerLimit": true,
+                "inputVariables": [],
                 "step_variables": {
                     "input": {
-                        "params": {
-                            "summary": "{{vars.request.data[\"summary\"]}}",
-                            "assignee": "{{vars.request.data[\"assignee\"]}}",
-                            "description": "{{vars.request.data[\"description\"]}}"
-                        },
+                        "params": [],
                         "records": "{{vars.input.records}}"
                     }
                 },
                 "_promptexpanded": true,
+                "triggerOnSource": true,
                 "executeButtonText": "Submit",
                 "noRecordExecution": true,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
                 "singleRecordExecution": false
             },
             "status": null,
             "top": "30",
-            "left": "310",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "9b3eba7c-8cc9-4c39-aea5-05b2df668ae4"
@@ -395,17 +311,17 @@
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "d514b808-0ae2-467c-8157-a3d5ae2b7d7e"
+            "uuid": "f0f75937-2e1e-4645-aa8b-97e768e9df16"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Is Username Available",
-            "targetStep": "\/api\/3\/workflow_steps\/14ab3b78-7479-4cf2-9aef-e507664407c6",
+            "name": "Configuration -> Create Issue",
+            "targetStep": "\/api\/3\/workflow_steps\/142799f7-839a-4e01-b9a1-962a8d7a826d",
             "sourceStep": "\/api\/3\/workflow_steps\/20429145-4b50-4df0-a0c8-cde5d66ccd7e",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "20896b3c-70a9-4ef3-b9d2-0ab386ad2583"
+            "uuid": "4bcdd94c-f279-4203-b2e7-0cf60496faf7"
         },
         {
             "@type": "WorkflowRoute",
@@ -419,83 +335,33 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Configuration",
+            "name": "Create New Request -> Configuration",
             "targetStep": "\/api\/3\/workflow_steps\/20429145-4b50-4df0-a0c8-cde5d66ccd7e",
+            "sourceStep": "\/api\/3\/workflow_steps\/f87d6e93-7ed0-4a73-b3a8-0dba10b70241",
+            "label": "Submit",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fce529fa-5b2d-4a67-bcc6-c8c35ba4808a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Details -> Get Users",
+            "targetStep": "\/api\/3\/workflow_steps\/902690e1-0853-48a8-8244-a10801612e20",
             "sourceStep": "\/api\/3\/workflow_steps\/aa6d9b92-8a27-463a-94d0-63c28fef2630",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "b788d6a6-6489-44b3-809f-529553babb0f"
+            "uuid": "d79c1cf7-9b4f-49ac-98ae-a117f07dd243"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Username Available -> Placeholder",
-            "targetStep": "\/api\/3\/workflow_steps\/d47decc2-caa4-465f-918b-1575b94110f7",
-            "sourceStep": "\/api\/3\/workflow_steps\/14ab3b78-7479-4cf2-9aef-e507664407c6",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "e710069b-4ab5-4f77-99cc-afc0324667ae"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Username Available -> Refresh User Version Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/c531f160-58b9-443b-9d8a-90557b64fc53",
-            "sourceStep": "\/api\/3\/workflow_steps\/14ab3b78-7479-4cf2-9aef-e507664407c6",
-            "label": "No",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "7f27deae-79ea-453c-ac86-1d84cc5fdd5e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Username Exist -> Create Issue",
-            "targetStep": "\/api\/3\/workflow_steps\/142799f7-839a-4e01-b9a1-962a8d7a826d",
-            "sourceStep": "\/api\/3\/workflow_steps\/b69c479a-284f-45c8-bc02-ca0c258e44d7",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "96d7e811-df48-4f20-8418-3913e78dd0c7"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Username Exist -> Source Control User Not Mapped",
-            "targetStep": "\/api\/3\/workflow_steps\/f9ff1afb-9ed5-42d9-bd79-24b1d53fa483",
-            "sourceStep": "\/api\/3\/workflow_steps\/b69c479a-284f-45c8-bc02-ca0c258e44d7",
-            "label": "No",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "f67f2988-64a9-4c1e-a1b8-a487afbf874e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Placeholder -> Create Iss",
-            "targetStep": "\/api\/3\/workflow_steps\/142799f7-839a-4e01-b9a1-962a8d7a826d",
-            "sourceStep": "\/api\/3\/workflow_steps\/d47decc2-caa4-465f-918b-1575b94110f7",
+            "name": "Get Users -> hgvh",
+            "targetStep": "\/api\/3\/workflow_steps\/f87d6e93-7ed0-4a73-b3a8-0dba10b70241",
+            "sourceStep": "\/api\/3\/workflow_steps\/902690e1-0853-48a8-8244-a10801612e20",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c12ee1e9-7ca2-468c-9ece-574ad1d11a2e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Refresh User Version Control Details -> Is Username Exist",
-            "targetStep": "\/api\/3\/workflow_steps\/b69c479a-284f-45c8-bc02-ca0c258e44d7",
-            "sourceStep": "\/api\/3\/workflow_steps\/c531f160-58b9-443b-9d8a-90557b64fc53",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "d7716688-b4ba-4ffc-afda-c36c6ddfa326"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Source Control User Not Mapped -> No Operation",
-            "targetStep": "\/api\/3\/workflow_steps\/63f36a6a-2cbc-4cab-a2d2-7ed00519fef8",
-            "sourceStep": "\/api\/3\/workflow_steps\/f9ff1afb-9ed5-42d9-bd79-24b1d53fa483",
-            "label": "Ok",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "db3aaf56-bdfa-4343-91d0-527d88f0ed7a"
+            "uuid": "7405cc1b-cc6f-43e3-930b-e651e7a9a141"
         },
         {
             "@type": "WorkflowRoute",
@@ -505,7 +371,7 @@
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "94a0ede0-bfbb-454b-a3b2-f6d996ed2b59"
+            "uuid": "12f79c69-b8b2-4565-8469-3aee9bed4c45"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
@@ -21,10 +21,10 @@
             "name": "Configuration",
             "description": null,
             "arguments": {
-                "current_user_source_control_connector_config_id": "{% if vars.request['currentUser'] is defined %}{{(vars.steps.Get_Source_Control_Connector_Configurations.data.configuration | json_query(\"[?config.username=='\"+(vars.request['currentUser'] | fromIRI).sourceControlUsername+\"'].config_id\"))[0]}}{% else %}{{(vars.steps.Get_Source_Control_Connector_Configurations.data.configuration | json_query(\"[?config.username=='\"+(vars.currentUser | fromIRI).sourceControlUsername+\"'].config_id\"))[0]}}{% endif %}"
+                "current_user_source_control_connector_config_id": "{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name==connector_config.config.username %}{{connector_config.config_id}}{% break %}{% endif %}{% endfor %}"
             },
             "status": null,
-            "top": "435",
+            "top": "440",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -44,7 +44,9 @@
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": []
+                "step_variables": {
+                    "logged_in_user_sc_name": "{{((vars.currentUser or vars.request['currentUser'] ) | fromIRI).sourceControlUsername}}"
+                }
             },
             "status": null,
             "top": "165",
@@ -90,7 +92,7 @@
                     {
                         "option": "Yes",
                         "step_iri": "\/api\/3\/workflow_steps\/2c4669a5-feca-4025-98f9-190c4ac2020c",
-                        "condition": "{{ (((vars.currentUser | fromIRI).sourceControlUsername) or ((vars.request['currentUser'] | fromIRI).sourceControlUsername))==(vars.steps.Get_Source_Control_Connector_Configurations.data.configuration[0].name) }}",
+                        "condition": "{{ vars.logged_in_user_sc_name != None }}",
                         "step_name": "Configuration"
                     },
                     {
@@ -115,7 +117,7 @@
             "description": null,
             "arguments": {
                 "params": {
-                    "msg": "{% if (vars.currentUser | fromIRI).sourceControlUsername != (vars.request['currentUser'] | fromIRI).sourceControlUsername %}{{\"Logged in FortiSOAR User is not Mapped with Source Control Username\"}}{% else %}{{vars.cicd_env[\"source_control\"][\"label\"]}} connector is not configured for the logged in User.{% endif %}"
+                    "msg": "{% if vars.logged_in_user_sc_name == None %}{{\"Logged in FortiSOAR User is not Mapped with Source Control Username\"}}{% else %}{{vars.cicd_env[\"source_control\"][\"label\"]}} connector is not configured for the logged in User.{% endif %}"
                 },
                 "version": "3.2.6",
                 "connector": "cyops_utilities",


### PR DESCRIPTION
#### Change:
- Updated Jinja in `Get Source Control Connector Configuration` playbook.
- Updated `Create a Request (Issue)` playbook as it should list only Source Control Username Mapped users to Assign a change request.

#### UTCs:
- [x] Tested and verified `Get Source Control Connector Configuration` playbook with following cases:
    - Logged in user is not mapped with source control username.
    - Logged in user is mapped with source control username but does not have connector configured.
    - Logged in user is mapped with source control username and and have connector configured.
- [x] Tested and verified `Create a Request (Issue)` playbook with following details:
    - It should list only Source Control Username Mapped users to Assign a change request.
    - Issue is created with valid input details, summary , title and assignee.