### PR TITLE
Updated playbook jinja to check for repo name dynamically

### DIFF
--- a/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
@@ -25,13 +25,15 @@
                     "playbook_name": "Push Change to Source Control"
                 },
                 "apply_async": false,
-                "step_variables": [],
+                "step_variables": {
+                    "cicd_config": "{{globalVars.cicd_config | toDict}}"
+                },
                 "pass_parent_env": false,
                 "pass_input_record": true,
                 "workflowReference": "\/api\/3\/workflows\/2bf34362-0466-4590-9ce5-845ce08860bc"
             },
             "status": null,
-            "top": "435",
+            "top": "440",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -62,15 +64,14 @@
             "description": null,
             "arguments": {
                 "issue_no": "{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
-                "repo_name": "{{(vars.input.records[0].repo_url.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
+                "repo_name": "{{vars.cicd_config[\"contentRepoName\"]}}",
                 "new_branch": "CR-{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
                 "repo_owner": "{{vars.input.records[0].assigneeUsername}}",
-                "base_branch": "{{vars.input.records[0].baseBranch}}",
                 "cicd_config": "{{globalVars.cicd_config | toDict}}",
                 "export_file_name": "FortiSOAR Export-{{arrow.utcnow().int_timestamp}}",
                 "current_timestamp": "{{arrow.get((arrow.utcnow().int_timestamp  | int | abs)).format('YYYYMMDDHHmm')}}",
                 "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}",
-                "export_template_name": "{% if \"fortisoar-prod-content\" in vars.input.records[0].repo_url %}Source Control - Production Content{% elif \"fortisoar-dev-settings\" in vars.input.records[0].repo_url %}Source Control - Development Settings{% else %}Source Control - Production Settings{% endif %}"
+                "export_template_name": "{% if vars.cicd_config[\"contentRepoName\"] in vars.input.records[0].repo_url %}Source Control - Production Content{% elif vars.cicd_config[\"devSettingsRepoName\"] in vars.input.records[0].repo_url %}Source Control - Development Settings{% else %}Source Control - Production Settings{% endif %}"
             },
             "status": null,
             "top": "705",
@@ -129,7 +130,7 @@
                 ]
             },
             "status": null,
-            "top": "570",
+            "top": "580",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,


### PR DESCRIPTION
#### Fix:
- 0979059: For all CICD operation default template is selected as `Source Control - Production Settings`.

#### UTCs:
- [x] Tested and verified `Push Change to Source Control` playbook with changing repositories names.