### PR TITLE
BugFixes

### DIFF
--- a/playbooks/02 - Use Case - CICD/Configure Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Configure Source Control.json
@@ -41,7 +41,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -68,7 +68,7 @@
                 ]
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "485",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -79,10 +79,10 @@
             "name": "Configuration",
             "description": null,
             "arguments": {
-                "source_control_type": "{{vars.steps.Get_Repositories_Detail.input.sourceControlWebURL}}"
+                "source_control_base_url": "{{vars.cicd_env.source_control.baseURL}}"
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -112,7 +112,7 @@
                 "workflowReference": "\/api\/3\/workflows\/712f286a-2edb-4c25-ba2f-e55a299f5dea"
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "485",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -145,7 +145,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1380",
             "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -162,20 +162,6 @@
                         "title": "Source Control Details",
                         "description": "Provide the following repository configuration inputs: ",
                         "inputVariables": [
-                            {
-                                "name": "sourceControlWebURL",
-                                "type": "string",
-                                "label": "Source Control Web URL",
-                                "tooltip": "Specify the web URL of the selected source control. For example, if you selected GitHub then specify https:\/\/github.com",
-                                "dataType": "text",
-                                "formType": "text",
-                                "required": true,
-                                "_expanded": true,
-                                "defaultValue": null,
-                                "_previousName": "sourceConWebURL",
-                                "jinjaExpressionView": true,
-                                "useRecordFieldDefault": false
-                            },
                             {
                                 "name": "orgName",
                                 "type": "string",
@@ -287,11 +273,36 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "165",
+            "top": "300",
             "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "4858af16-8286-4b28-8389-e3fcd3d7fe3e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Details",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name=cicd_env",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.3.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "cicd_env": "{% if vars.result.data['hydra:member'] | length %}{{vars.result.data['hydra:member'][0].value | toDict }}{% else %}\"\"{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "310",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "f8a73194-eca6-4b60-a614-3da740ad9667"
         },
         {
             "@type": "WorkflowStep",
@@ -302,7 +313,7 @@
                 "input": {
                     "schema": {
                         "title": "Repositories Existence Confirmation",
-                        "description": "Confirm that the following repositories have been created:\n(You can click on the hyperlink to verify)<br>\n\n\n**Production Content Repository**: <a href=\"{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}<\/a><br>\n\n\n**Production Settings Repository**: <a href=\"{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}<\/a><br>\n\n\n**Development Settings Repository**:  <a href=\"{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}<\/a>\n\n",
+                        "description": "Confirm that the following repositories have been created:\n(You can click on the hyperlink to verify)<br>\n\n\n**Production Content Repository**: <a href=\"{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}<\/a><br>\n\n\n**Production Settings Repository**: <a href=\"{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}<\/a><br>\n\n\n**Development Settings Repository**:  <a href=\"{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}<\/a>\n\n",
                         "inputVariables": []
                     }
                 },
@@ -311,7 +322,8 @@
                 "resources": "change_management",
                 "is_approval": false,
                 "owner_detail": {
-                    "isAssigned": false
+                    "isAssigned": false,
+                    "emailRecipients": ""
                 },
                 "isRecordLinked": true,
                 "step_variables": {
@@ -332,12 +344,17 @@
                     "enabled": false,
                     "smtpParameters": []
                 },
+                "customEmailExternal": false,
                 "inline_channel_list": [],
                 "external_channel_list": [],
-                "unauthenticated_input": false
+                "unauthenticated_input": false,
+                "external_email_subject": null,
+                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
+                "custom_email_body_external": null,
+                "external_email_attachments": null
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -349,13 +366,13 @@
             "description": null,
             "arguments": {
                 "base_branch": "{{vars.steps.Get_Repositories_Detail.input.baseBranchName}}",
-                "content_repo": "{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}",
-                "dev_settings": "{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}",
-                "prod_settings": "{{vars.source_control_type}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}",
+                "content_repo": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}",
+                "dev_settings": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}",
+                "prod_settings": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}",
                 "organization_name": "{{vars.steps.Get_Repositories_Detail.input.orgName}}"
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -369,7 +386,7 @@
                 "are_repo_created_manually": "{% if vars.are_repo_created is defined %}{{vars.are_repo_created}}{% else %}{{false}}{% endif %}"
             },
             "status": null,
-            "top": "1515",
+            "top": "1650",
             "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -383,7 +400,7 @@
                 "is_status_failed": "{{vars.steps.Create_All_Repositories[0].is_status_failed}}"
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "495",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -396,16 +413,16 @@
             "arguments": {
                 "params": {
                     "macro": "{{\"cicd_config\"}}",
-                    "value": "{{ ({\"source_control_web_url\": vars.steps.Get_Repositories_Detail.input.sourceControlWebURL,\"organizationName\": vars.organization_name, \"content\": vars.content_repo, \"productionSettings\": vars.prod_settings, \"developmentSettings\": vars.dev_settings, \"baseBranch\": vars.base_branch,\"contentRepoName\": vars.steps.Get_Repositories_Detail.input.contentRepositoryName, \"prodSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName, \"devSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}) | toJSON }}"
+                    "value": "{{ ({\"source_control_web_url\": vars.source_control_base_url,\"organizationName\": vars.organization_name, \"content\": vars.content_repo, \"productionSettings\": vars.prod_settings, \"developmentSettings\": vars.dev_settings, \"baseBranch\": vars.base_branch,\"contentRepoName\": vars.steps.Get_Repositories_Detail.input.contentRepositoryName, \"prodSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName, \"devSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}) | toJSON }}"
                 },
-                "version": "3.2.6",
+                "version": "3.3.0",
                 "connector": "cyops_utilities",
                 "operation": "updatemacro",
                 "operationTitle": "FSR: Create\/Update Global Variables",
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
+            "top": "1245",
             "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -454,7 +471,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -507,7 +524,7 @@
                 "unauthenticated_input": false
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -564,6 +581,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "85b66b11-1797-4572-81e8-8c62d078fb78"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Details -> Get Repositories Detail",
+            "targetStep": "\/api\/3\/workflow_steps\/4858af16-8286-4b28-8389-e3fcd3d7fe3e",
+            "sourceStep": "\/api\/3\/workflow_steps\/f8a73194-eca6-4b60-a614-3da740ad9667",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ca014b57-2321-4882-9442-b49f327cf104"
         },
         {
             "@type": "WorkflowRoute",
@@ -637,13 +664,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get Repositories Detail",
-            "targetStep": "\/api\/3\/workflow_steps\/4858af16-8286-4b28-8389-e3fcd3d7fe3e",
+            "name": "Start -> Get Source Control Details",
+            "targetStep": "\/api\/3\/workflow_steps\/f8a73194-eca6-4b60-a614-3da740ad9667",
             "sourceStep": "\/api\/3\/workflow_steps\/601f718e-64a7-4e5f-a022-dac1423b613f",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "927379bf-263a-4de8-8441-fdf5bf404b42"
+            "uuid": "cf14114a-d19f-4686-9a0a-1ce1f824ec1b"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
@@ -33,7 +33,7 @@
                 "workflowReference": "\/api\/3\/workflows\/2bf34362-0466-4590-9ce5-845ce08860bc"
             },
             "status": null,
-            "top": "440",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -67,10 +67,11 @@
                 "repo_name": "{{vars.cicd_config[\"contentRepoName\"]}}",
                 "new_branch": "CR-{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
                 "repo_owner": "{{vars.input.records[0].assigneeUsername}}",
+                "base_branch": "{{vars.input.records[0].baseBranch}}",
                 "cicd_config": "{{globalVars.cicd_config | toDict}}",
                 "export_file_name": "FortiSOAR Export-{{arrow.utcnow().int_timestamp}}",
                 "current_timestamp": "{{arrow.get((arrow.utcnow().int_timestamp  | int | abs)).format('YYYYMMDDHHmm')}}",
-                "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}",
+                "source_control_type": "{{(globalVars.cicd_env| toDict).source_control.baseURL}}",
                 "export_template_name": "{% if vars.cicd_config[\"contentRepoName\"] in vars.input.records[0].repo_url %}Source Control - Production Content{% elif vars.cicd_config[\"devSettingsRepoName\"] in vars.input.records[0].repo_url %}Source Control - Development Settings{% else %}Source Control - Production Settings{% endif %}"
             },
             "status": null,
@@ -130,7 +131,7 @@
                 ]
             },
             "status": null,
-            "top": "580",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,

--- a/playbooks/02 - Use Case - CICD/Set Logged in Source Control Username.json
+++ b/playbooks/02 - Use Case - CICD/Set Logged in Source Control Username.json
@@ -139,12 +139,15 @@
             "name": "Start",
             "description": null,
             "arguments": {
+                "__triggerLimit": true,
                 "step_variables": {
                     "input": {
                         "params": []
                     },
-                    "logged_in_user": "{{(vars.currentUser | fromIRI).firstname}} {{(vars.currentUser | fromIRI).lastname}}"
-                }
+                    "logged_in_user": "{{((vars.currentUser | fromIRI).firstname) or ((vars.request.currentUser | fromIRI).firstname)}} {{((vars.currentUser | fromIRI).lastname) or ((vars.request.currentUser | fromIRI).lastname)}}"
+                },
+                "triggerOnSource": true,
+                "triggerOnReplicate": false
             },
             "status": null,
             "top": "30",

--- a/playbooks/02 - Use Case - CICD/Setup Development Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup Development Environment.json
@@ -1,5 +1,4 @@
 {
-    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Setup Development Environment",
@@ -51,7 +50,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CloneRepository\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1650",
+            "top": "1785",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -80,7 +79,7 @@
                     "macro": "{{\"cicd_config\"}}",
                     "value": "{{ ({\"organizationName\": vars.organization_name, \"content\": vars.content_repo_url, \"developmentSettings\": vars.dev_settings_url, \"baseBranch\": vars.base_branch,  \"contentRepoName\": vars.content_repo_url.split(\"\/\")[-1], \"devSettingsRepoName\": vars.dev_settings_url.split(\"\/\")[-1]}) | toJSON}}"
                 },
-                "version": "3.2.3",
+                "version": "3.3.0",
                 "connector": "cyops_utilities",
                 "operation": "updatemacro",
                 "operationTitle": "FSR: Create\/Update Global Variables",
@@ -89,11 +88,36 @@
                 }
             },
             "status": null,
-            "top": "1240",
-            "left": "540",
+            "top": "1380",
+            "left": "520",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "747f53dd-ba2f-4e8f-85b9-79f1ee762909"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Fetch Source Control Details",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name=cicd_env",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.3.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "cicd_env": "{% if vars.result.data['hydra:member'] | length %}{{vars.result.data['hydra:member'][0].value | toDict }}{% else %}\"\"{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "1120",
+            "left": "520",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "99743434-451f-4875-80a0-97015a247b59"
         },
         {
             "@type": "WorkflowStep",
@@ -122,7 +146,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2190",
+            "top": "2325",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -139,20 +163,6 @@
                         "title": "Provide Repository Configuration Details",
                         "description": "Provide the following repository configuration inputs",
                         "inputVariables": [
-                            {
-                                "name": "sourceControlWebURL",
-                                "type": "string",
-                                "label": "Source Control Web URL",
-                                "tooltip": "Specify the web URL of the selected source control. For example, if you selected GitHub then specify https:\/\/github.com",
-                                "dataType": "text",
-                                "formType": "text",
-                                "required": false,
-                                "_expanded": false,
-                                "defaultValue": null,
-                                "_previousName": "",
-                                "jinjaExpressionView": true,
-                                "useRecordFieldDefault": false
-                            },
                             {
                                 "name": "orgName",
                                 "type": "string",
@@ -228,7 +238,7 @@
                         {
                             "option": "Setup",
                             "primary": true,
-                            "step_iri": "\/api\/3\/workflow_steps\/f8146597-a026-47dd-8c57-2cec35cc752b"
+                            "step_iri": "\/api\/3\/workflow_steps\/99743434-451f-4875-80a0-97015a247b59"
                         }
                     ],
                     "duplicateOption": false,
@@ -248,8 +258,8 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "960",
-            "left": "540",
+            "top": "980",
+            "left": "520",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "908ec37d-cb1f-4c45-955a-11324893b0d3"
@@ -324,7 +334,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1785",
+            "top": "1920",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -359,7 +369,7 @@
                 "dev_settings_repo": "{{vars.cicd_config.developmentSettings.split('\/')[-1] or vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}"
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -389,7 +399,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2325",
+            "top": "2460",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -401,13 +411,13 @@
             "description": null,
             "arguments": {
                 "base_branch": "{{vars.steps.Get_Repositories_Details.input.baseBranchName}}",
-                "content_repo_url": "{{vars.steps.Get_Repositories_Details.input.sourceControlWebURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
-                "dev_settings_url": "{{vars.steps.Get_Repositories_Details.input.sourceControlWebURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}",
+                "content_repo_url": "{{vars.cicd_env.source_control.baseURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
+                "dev_settings_url": "{{vars.cicd_env.source_control.baseURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}",
                 "organization_name": "{{vars.steps.Get_Repositories_Details.input.orgName}}"
             },
             "status": null,
-            "top": "1100",
-            "left": "540",
+            "top": "1240",
+            "left": "520",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "f8146597-a026-47dd-8c57-2cec35cc752b"
@@ -428,7 +438,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2055",
+            "top": "2190",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -538,22 +548,24 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
                     "thread": false,
-                    "content": "<p class=\"mp-tile-description muted-80\"><strong>- Identified source control repositories names as follows: <\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li><em>Production Content: <\/em><a href=\"{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.content_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.content_repo}}<\/a><\/li>\n<li><em>Development Settings: <\/em><a href=\"{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.dev_settings_repo}}<\/a><\/li>\n<\/ul>",
+                    "content": "<p class=\"mp-tile-description muted-80\"><strong>- Identified source control repositories names as follows: <\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li><em>Production Content: <\/em><a href=\"{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.content_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.content_repo}}<\/a><\/li>\n<li><em>Development Settings: <\/em><a href=\"{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.dev_settings_repo}}<\/a><\/li>\n<\/ul>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b18cb44c-0425-4a09-9438-7f0f455a4c24"
                 },
                 "resource": {
-                    "results": "<p class=\"mp-tile-description muted-80\"><strong>- Identified source control repositories names as follows: <\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li><em>Production Content: <\/em><a rel=\"noopener\" target=\"_blank\" href=\"{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.content_repo}}\">{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.content_repo}}<\/a><\/li>\n<li><em>Development Settings: <\/em><a rel=\"noopener\" target=\"_blank\" href=\"{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}\">{{vars.source_control_url}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}<\/a><\/li>\n<\/ul>"
+                    "results": "<p class=\"mp-tile-description muted-80\"><strong>- Identified source control repositories names as follows: <\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li><em>Production Content: <\/em><a href=\"{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.content_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.content_repo}}<\/a><\/li>\n<li><em>Development Settings: <\/em><a href=\"{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}\" target=\"_blank\" rel=\"noopener\">{{vars.cicd_env.source_control.baseURL}}\/{{vars.org_name}}\/{{vars.dev_settings_repo}}<\/a><\/li>\n<\/ul>"
                 },
                 "operation": "Append",
                 "collection": "{{vars.input.records[0]['@id']}}",
                 "__recommend": [],
                 "collectionType": "\/api\/3\/change_management",
-                "fieldOperation": [],
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "1650",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -585,7 +597,7 @@
                 }
             },
             "status": null,
-            "top": "1920",
+            "top": "2055",
             "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
@@ -655,6 +667,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Fetch Source Control Details -> Set Source Control Parameters",
+            "targetStep": "\/api\/3\/workflow_steps\/f8146597-a026-47dd-8c57-2cec35cc752b",
+            "sourceStep": "\/api\/3\/workflow_steps\/99743434-451f-4875-80a0-97015a247b59",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fbf56e6c-8d8e-4f76-8190-e75bbfd2a272"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Find Apply Latest Content Record -> Update Latest Deployed Date",
             "targetStep": "\/api\/3\/workflow_steps\/a20d0c91-0db4-4716-acb2-5ef1fb5f501a",
             "sourceStep": "\/api\/3\/workflow_steps\/762289c3-2ae5-445f-bd09-8262327e4d24",
@@ -665,13 +687,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Repositories Detail -> Copy of Repository Details",
-            "targetStep": "\/api\/3\/workflow_steps\/f8146597-a026-47dd-8c57-2cec35cc752b",
+            "name": "Get Repositories Details -> Fetch Source Control Details",
+            "targetStep": "\/api\/3\/workflow_steps\/99743434-451f-4875-80a0-97015a247b59",
             "sourceStep": "\/api\/3\/workflow_steps\/908ec37d-cb1f-4c45-955a-11324893b0d3",
             "label": "Setup",
             "isExecuted": false,
             "group": null,
-            "uuid": "d21df009-3e89-4164-b4f5-0497ffef540c"
+            "uuid": "13e9e72e-12b2-4509-a93a-8a337dcf2b85"
         },
         {
             "@type": "WorkflowRoute",


### PR DESCRIPTION
- Removed Manual Input of Source Control Base URL 
- Fetch the Source Control Base URL from cicd_env global variable 
- Change the Jinja's according to the global variable 

Test Case:
- Take Base URL from CICD Configuration Wizard which will add it in cicd_env global variable
- Test End to End CICD flow by setting up the Dev and Prod instance 