### PR TITLE
BugFixes and Enhancements

### DIFF
--- a/modules/change_management/detail-layout.json
+++ b/modules/change_management/detail-layout.json
@@ -3155,7 +3155,8 @@
                                                                                                                                 "itemValue": "Production",
                                                                                                                                 "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
                                                                                                                             },
-                                                                                                                            "type": "object"
+                                                                                                                            "type": "object",
+                                                                                                                            "display": "Production"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 }
@@ -3318,7 +3319,8 @@
                                                                                                                                 "itemValue": "Development",
                                                                                                                                 "@id": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651"
                                                                                                                             },
-                                                                                                                            "type": "object"
+                                                                                                                            "type": "object",
+                                                                                                                            "display": "Development"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 }
@@ -3326,7 +3328,144 @@
                                                                                                         }
                                                                                                     }
                                                                                                 ],
-                                                                                                "style": "col-lg-12"
+                                                                                                "style": "col-lg-6"
+                                                                                            },
+                                                                                            {
+                                                                                                "widgets": [
+                                                                                                    {
+                                                                                                        "type": "sectionHeader",
+                                                                                                        "config": {
+                                                                                                            "wid": "00d3b28c-60ee-4301-a68a-899e559429b4",
+                                                                                                            "query": {
+                                                                                                                "filters": [],
+                                                                                                                "sort": [],
+                                                                                                                "limit": 10
+                                                                                                            },
+                                                                                                            "editorType": "html",
+                                                                                                            "sectionText": "<div style=\"font-family: Lato, sans-serif; font-size: 13px; font-weight: 400;\" class=\"muted-80\">\n<p><strong>Configuration Parameters<\/strong><\/p>\n<br>\n<p>Defines the source control configuration used during CICD setup, including base branch, repository names, and source control URL.<\/p>\n<p>It's recommended to verify these values before executing Git operations such as applying the latest content or pushing changes.<\/p>\n<\/div>",
+                                                                                                            "visibility": {
+                                                                                                                "conditionalVisibility": true,
+                                                                                                                "filter": {
+                                                                                                                    "sort": [],
+                                                                                                                    "limit": 30,
+                                                                                                                    "logic": "AND",
+                                                                                                                    "filters": [
+                                                                                                                        {
+                                                                                                                            "field": "title",
+                                                                                                                            "operator": "eq",
+                                                                                                                            "_operator": "eq",
+                                                                                                                            "value": "Source Control Settings",
+                                                                                                                            "type": "primitive"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "field": "environment",
+                                                                                                                            "value": [
+                                                                                                                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                                                                                                                "48b9f120-34bc-4884-b886-85e82321684b"
+                                                                                                                            ],
+                                                                                                                            "display": "",
+                                                                                                                            "operator": "in",
+                                                                                                                            "type": "object",
+                                                                                                                            "OPERATOR_KEY": "$",
+                                                                                                                            "displayTemplate": "",
+                                                                                                                            "module": "environment",
+                                                                                                                            "template": "multiselectpicklist",
+                                                                                                                            "previousOperator": "in",
+                                                                                                                            "previousTemplate": "multiselectpicklist",
+                                                                                                                            "useInOperator": true
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "editableFormGroup",
+                                                                                                        "config": {
+                                                                                                            "wid": "0e65ef15-37c0-4a62-b7cf-7fabffdd0836",
+                                                                                                            "rows": [
+                                                                                                                {
+                                                                                                                    "columns": [
+                                                                                                                        {
+                                                                                                                            "fields": [
+                                                                                                                                {
+                                                                                                                                    "name": "configurationParameters",
+                                                                                                                                    "highlightMode": true,
+                                                                                                                                    "linky": true,
+                                                                                                                                    "readOnly": true,
+                                                                                                                                    "renderWidget": "json",
+                                                                                                                                    "renderWidgetHeight": 250
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "visibility": {
+                                                                                                                "conditionalVisibility": true,
+                                                                                                                "filter": {
+                                                                                                                    "sort": [],
+                                                                                                                    "limit": 30,
+                                                                                                                    "logic": "AND",
+                                                                                                                    "filters": [
+                                                                                                                        {
+                                                                                                                            "field": "title",
+                                                                                                                            "operator": "eq",
+                                                                                                                            "_operator": "eq",
+                                                                                                                            "value": "Source Control Settings",
+                                                                                                                            "type": "primitive"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "field": "environment",
+                                                                                                                            "value": [
+                                                                                                                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                                                                                                                "48b9f120-34bc-4884-b886-85e82321684b"
+                                                                                                                            ],
+                                                                                                                            "display": "",
+                                                                                                                            "operator": "in",
+                                                                                                                            "type": "array",
+                                                                                                                            "OPERATOR_KEY": "$",
+                                                                                                                            "module": "environment",
+                                                                                                                            "template": "multiselectpicklist",
+                                                                                                                            "previousOperator": "in",
+                                                                                                                            "previousTemplate": "multiselectpicklist",
+                                                                                                                            "useInOperator": true
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            },
+                                                                                                            "usePlaceholder": true
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "playbookButtons-1.1.0",
+                                                                                                        "config": {
+                                                                                                            "wid": "97afe81f-c070-4479-bfab-f0a676679f64",
+                                                                                                            "widgetName": "Playbook Execution Wizard",
+                                                                                                            "selectedPlaybooksWithRecord": [
+                                                                                                                {
+                                                                                                                    "name": "Update Source Control Configuration",
+                                                                                                                    "uuid": "44b750e6-8606-4c48-8bb6-43beea85b09e",
+                                                                                                                    "actionTriggerName": "Update Source Control Configuration",
+                                                                                                                    "collectionName": "01 - Drafts",
+                                                                                                                    "icon": "icon icon-update-record"
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "showExecutionProgress": true,
+                                                                                                            "selectedExecutionWizardPlaybooks": [
+                                                                                                                {
+                                                                                                                    "name": "Update Source Control Configuration",
+                                                                                                                    "uuid": "44b750e6-8606-4c48-8bb6-43beea85b09e",
+                                                                                                                    "actionTriggerName": "Update Source Control Configuration",
+                                                                                                                    "collectionName": "01 - Drafts",
+                                                                                                                    "icon": "icon icon-update-record"
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "showPrimaryButton": true
+                                                                                                        }
+                                                                                                    }
+                                                                                                ],
+                                                                                                "style": "col-lg-6"
                                                                                             }
                                                                                         ],
                                                                                         "wid": "95d82eb2-1d9b-4e18-9c0c-52a4879d9d78",

--- a/modules/change_management/languages/en.json
+++ b/modules/change_management/languages/en.json
@@ -5,6 +5,7 @@
             "PLURAL_NAME": "Change Management"
         },
         "FIELDS": {
+            "CONFIGURATIONPARAMETERS": "Configuration Parameters",
             "COMMITSTATUS": "Commit Status",
             "LASTCOMMITID": "Last Commit ID",
             "ISSUES": "Issues",

--- a/modules/change_management/languages/fr.json
+++ b/modules/change_management/languages/fr.json
@@ -5,6 +5,7 @@
             "PLURAL_NAME": "Gestion du changement"
         },
         "FIELDS": {
+            "CONFIGURATIONPARAMETERS_FR": "Paramètres de configuration",
             "COMMITSTATUS": "Statut de validation",
             "LASTCOMMITID": "Dernier ID de validation",
             "ISSUES": "Problèmes",

--- a/modules/change_management/languages/fr.json
+++ b/modules/change_management/languages/fr.json
@@ -5,7 +5,7 @@
             "PLURAL_NAME": "Gestion du changement"
         },
         "FIELDS": {
-            "CONFIGURATIONPARAMETERS_FR": "Paramètres de configuration",
+            "CONFIGURATIONPARAMETERS": "Paramètres de configuration",
             "COMMITSTATUS": "Statut de validation",
             "LASTCOMMITID": "Dernier ID de validation",
             "ISSUES": "Problèmes",

--- a/modules/change_management/languages/ja.json
+++ b/modules/change_management/languages/ja.json
@@ -5,6 +5,7 @@
             "PLURAL_NAME": "変更管理"
         },
         "FIELDS": {
+            "CONFIGURATIONPARAMETERS_JA": "設定パラメーター",
             "COMMITSTATUS": "コミットステータス",
             "LASTCOMMITID": "最終コミットID",
             "ISSUES": "問題",

--- a/modules/change_management/languages/ja.json
+++ b/modules/change_management/languages/ja.json
@@ -5,7 +5,7 @@
             "PLURAL_NAME": "変更管理"
         },
         "FIELDS": {
-            "CONFIGURATIONPARAMETERS_JA": "設定パラメーター",
+            "CONFIGURATIONPARAMETERS": "設定パラメーター",
             "COMMITSTATUS": "コミットステータス",
             "LASTCOMMITID": "最終コミットID",
             "ISSUES": "問題",

--- a/modules/change_management/languages/ko.json
+++ b/modules/change_management/languages/ko.json
@@ -5,7 +5,7 @@
             "PLURAL_NAME": "변경 관리"
         },
         "FIELDS": {
-            "CONFIGURATIONPARAMETERS_KO": "구성 매개변수",
+            "CONFIGURATIONPARAMETERS": "구성 매개변수",
             "COMMITSTATUS": "커밋 상태",
             "LASTCOMMITID": "마지막 커밋 ID",
             "ISSUES": "이슈",

--- a/modules/change_management/languages/ko.json
+++ b/modules/change_management/languages/ko.json
@@ -5,6 +5,7 @@
             "PLURAL_NAME": "변경 관리"
         },
         "FIELDS": {
+            "CONFIGURATIONPARAMETERS_KO": "구성 매개변수",
             "COMMITSTATUS": "커밋 상태",
             "LASTCOMMITID": "마지막 커밋 ID",
             "ISSUES": "이슈",

--- a/modules/change_management/languages/zh_cn.json
+++ b/modules/change_management/languages/zh_cn.json
@@ -5,7 +5,7 @@
             "PLURAL_NAME": "变更管理"
         },
         "FIELDS": {
-            "CONFIGURATIONPARAMETERS_ZH": "配置参数",
+            "CONFIGURATIONPARAMETERS": "配置参数",
             "COMMITSTATUS": "提交状态",
             "LASTCOMMITID": "最后提交ID",
             "ISSUES": "问题",

--- a/modules/change_management/languages/zh_cn.json
+++ b/modules/change_management/languages/zh_cn.json
@@ -5,6 +5,7 @@
             "PLURAL_NAME": "变更管理"
         },
         "FIELDS": {
+            "CONFIGURATIONPARAMETERS_ZH": "配置参数",
             "COMMITSTATUS": "提交状态",
             "LASTCOMMITID": "最后提交ID",
             "ISSUES": "问题",

--- a/modules/change_management/list-layout.json
+++ b/modules/change_management/list-layout.json
@@ -63,10 +63,11 @@
                                                                                                     "409b289f-33f5-423f-9174-24bc8628cc4a",
                                                                                                     "dc57442c-3d52-43a0-aa19-ed2898e30ff7"
                                                                                                 ],
-                                                                                                "display": "",
+                                                                                                "display": "Setup",
                                                                                                 "operator": "nin",
                                                                                                 "type": "array",
                                                                                                 "OPERATOR_KEY": "$",
+                                                                                                "displayTemplate": "",
                                                                                                 "module": "type",
                                                                                                 "template": "multiselectpicklist",
                                                                                                 "previousOperator": "nin",
@@ -424,8 +425,8 @@
                                                 "visible": true
                                             },
                                             "icon": "fa fa-server",
-                                            "show": true,
-                                            "visible": true,
+                                            "show": false,
+                                            "visible": false,
                                             "conditionalVisibility": true,
                                             "filter": {
                                                 "sort": [],
@@ -433,29 +434,34 @@
                                                 "logic": "AND",
                                                 "filters": [
                                                     {
-                                                        "field": "key",
+                                                        "field": "title",
                                                         "operator": "eq",
                                                         "_operator": "eq",
-                                                        "value": "CICD FortiSOAR Environment",
+                                                        "value": "Setup the Source Control for Production Environment",
                                                         "type": "primitive"
                                                     },
                                                     {
-                                                        "field": "value",
-                                                        "operator": "like",
-                                                        "_operator": "like",
-                                                        "value": "%Production%",
-                                                        "type": "primitive"
+                                                        "field": "status",
+                                                        "operator": "eq",
+                                                        "value": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                                        "_value": {
+                                                            "display": "Completed",
+                                                            "itemValue": "Completed",
+                                                            "@id": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d"
+                                                        },
+                                                        "type": "object",
+                                                        "display": "Completed"
                                                     }
                                                 ]
                                             },
-                                            "resource": "keys"
+                                            "resource": "change_management"
                                         },
                                         {
                                             "title": "Development",
                                             "active": 0,
                                             "icon": "fa fa-code",
                                             "show": false,
-                                            "visible": true,
+                                            "visible": false,
                                             "widget": {
                                                 "type": "rows",
                                                 "config": {
@@ -708,25 +714,59 @@
                                             "filter": {
                                                 "sort": [],
                                                 "limit": 30,
-                                                "logic": "AND",
+                                                "logic": "OR",
                                                 "filters": [
                                                     {
-                                                        "field": "key",
-                                                        "operator": "eq",
-                                                        "_operator": "eq",
-                                                        "value": "CICD FortiSOAR Environment",
-                                                        "type": "primitive"
+                                                        "logic": "AND",
+                                                        "filters": [
+                                                            {
+                                                                "field": "title",
+                                                                "operator": "eq",
+                                                                "_operator": "eq",
+                                                                "value": "Setup the Source Control for Production Environment",
+                                                                "type": "primitive"
+                                                            },
+                                                            {
+                                                                "field": "status",
+                                                                "operator": "eq",
+                                                                "value": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                                                "_value": {
+                                                                    "display": "Completed",
+                                                                    "itemValue": "Completed",
+                                                                    "@id": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d"
+                                                                },
+                                                                "type": "object",
+                                                                "display": "Completed"
+                                                            }
+                                                        ]
                                                     },
                                                     {
-                                                        "field": "value",
-                                                        "operator": "like",
-                                                        "_operator": "like",
-                                                        "value": "%Development%",
-                                                        "type": "primitive"
+                                                        "logic": "AND",
+                                                        "filters": [
+                                                            {
+                                                                "field": "title",
+                                                                "operator": "eq",
+                                                                "_operator": "eq",
+                                                                "value": "Setup the Development Environment",
+                                                                "type": "primitive"
+                                                            },
+                                                            {
+                                                                "field": "status",
+                                                                "operator": "eq",
+                                                                "value": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                                                "_value": {
+                                                                    "display": "Completed",
+                                                                    "itemValue": "Completed",
+                                                                    "@id": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d"
+                                                                },
+                                                                "type": "object",
+                                                                "display": "Completed"
+                                                            }
+                                                        ]
                                                     }
                                                 ]
                                             },
-                                            "resource": "keys"
+                                            "resource": "change_management"
                                         }
                                     ]
                                 }

--- a/modules/change_management/mmd.json
+++ b/modules/change_management/mmd.json
@@ -26,6 +26,69 @@
     "attributes": [
         {
             "@type": "AttributeMetadata",
+            "type": "object",
+            "name": "configurationParameters",
+            "length": null,
+            "formType": "object",
+            "dataSource": null,
+            "searchable": false,
+            "peerReplicable": true,
+            "system": false,
+            "encrypted": false,
+            "gridColumn": false,
+            "collection": false,
+            "inversedField": null,
+            "ownsRelationship": false,
+            "validation": {
+                "required": false,
+                "minlength": 0,
+                "maxlength": 10485761,
+                "_enableRange": false
+            },
+            "bulkAction": {
+                "allow": false,
+                "buttonText": "",
+                "buttonIcon": "",
+                "buttonClass": "btn btn-default btn-sm"
+            },
+            "dataSourceFilters": null,
+            "defaultValue": null,
+            "tooltip": null,
+            "visibility": [
+                {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "field": "configurationParameters",
+                            "operator": "isnull",
+                            "value": "false",
+                            "_value": {
+                                "display": "",
+                                "itemValue": "",
+                                "@id": "false"
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            ],
+            "htmlEscape": false,
+            "orphanRemoval": null,
+            "readable": true,
+            "writeable": true,
+            "identifier": null,
+            "unique": false,
+            "recommend": false,
+            "skipSerialization": false,
+            "displayName": "{{ configurationParameters }}",
+            "descriptions": {
+                "singular": "Configuration Parameters"
+            }
+        },
+        {
+            "@type": "AttributeMetadata",
             "type": "string",
             "name": "commitStatus",
             "length": null,
@@ -65,13 +128,6 @@
                             "operator": "isnull",
                             "_operator": "isnull",
                             "value": "false",
-                            "type": "primitive"
-                        },
-                        {
-                            "field": "commitStatus",
-                            "operator": "isnull",
-                            "_operator": "isnull",
-                            "value": "null",
                             "type": "primitive"
                         }
                     ]
@@ -226,7 +282,8 @@
             "validation": {
                 "required": false,
                 "minlength": 0,
-                "maxlength": 10485761
+                "maxlength": 10485761,
+                "_enableRange": false
             },
             "bulkAction": {
                 "allow": false,
@@ -286,7 +343,8 @@
             "validation": {
                 "required": false,
                 "minlength": 0,
-                "maxlength": 10485761
+                "maxlength": 10485761,
+                "_enableRange": false
             },
             "bulkAction": [],
             "dataSourceFilters": null,
@@ -566,6 +624,7 @@
                             "operator": "eq",
                             "value": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
                             "_value": {
+                                "display": "Setup",
                                 "itemValue": "Setup",
                                 "@id": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c"
                             },
@@ -705,6 +764,10 @@
                     "262e570e-efe0-4eb0-aee9-e6e54b4ca3ef": {
                         "visibility": "visible",
                         "conditions": null
+                    },
+                    "5ec65649-9da5-4fcd-8198-48dcb548cf41": {
+                        "visibility": "visible",
+                        "conditions": null
                     }
                 }
             },
@@ -806,7 +869,8 @@
             "validation": {
                 "required": false,
                 "minlength": 0,
-                "maxlength": 10485761
+                "maxlength": 10485761,
+                "_enableRange": false
             },
             "bulkAction": {
                 "allow": false,

--- a/playbooks/02 - Use Case - CICD/Close Change Request.json
+++ b/playbooks/02 - Use Case - CICD/Close Change Request.json
@@ -38,7 +38,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -59,7 +59,7 @@
                 "workflowReference": "\/api\/3\/workflows\/2bf34362-0466-4590-9ce5-845ce08860bc"
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -100,7 +100,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"UpdateIssue\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1245",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -112,11 +112,10 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{globalVars.cicd_config}}",
-                "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}"
+                "source_control_type": "{{vars.cicd_config.source_control_url}}"
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -161,6 +160,59 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "a798432f-9155-4a0a-9ac6-d748425b4ee3"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Get Pull Request State",
             "description": null,
             "arguments": {
@@ -175,7 +227,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"ListPullRequest\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -203,7 +255,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -231,7 +283,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
+            "top": "1245",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -259,7 +311,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "1650",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -288,7 +340,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -317,7 +369,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -335,7 +387,7 @@
                 "issue_description": "{{vars.input.records[0].description}}"
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -434,13 +486,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/92e899e0-8a11-456d-8518-62f54ebf693f",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/a798432f-9155-4a0a-9ac6-d748425b4ee3",
             "sourceStep": "\/api\/3\/workflow_steps\/205a66af-b373-4197-9a24-a4358ebcb8e5",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "321b3723-a792-4c15-bed2-ff29ad005b6b"
+            "uuid": "116491ed-36bf-49e8-8244-1424a243ce1d"
         },
         {
             "@type": "WorkflowRoute",
@@ -481,6 +533,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "6c6b6afa-2efb-4c1f-a456-3b97f45e93f2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/92e899e0-8a11-456d-8518-62f54ebf693f",
+            "sourceStep": "\/api\/3\/workflow_steps\/a798432f-9155-4a0a-9ac6-d748425b4ee3",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "776b0838-a137-4d62-b604-fa61c59c6560"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Configure Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Configure Source Control.json
@@ -184,6 +184,46 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "environment",
+                            "value": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                                "display": "Production",
+                                "itemValue": "Production"
+                            },
+                            "operator": "eq"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1300",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "f8834aec-b964-4df6-99f6-35167ccff85e"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Get Base Branch Latest Commit",
             "description": null,
             "arguments": {
@@ -419,24 +459,6 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Repository Details",
-            "description": null,
-            "arguments": {
-                "base_branch": "{{vars.steps.Get_Repositories_Detail.input.baseBranchName}}",
-                "content_repo": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}",
-                "dev_settings": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}",
-                "prod_settings": "{{vars.source_control_base_url}}\/{{vars.steps.Get_Repositories_Detail.input.orgName}}\/{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}",
-                "organization_name": "{{vars.steps.Get_Repositories_Detail.input.orgName}}"
-            },
-            "status": null,
-            "top": "1280",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "56935f57-cf06-487f-8d0d-97ae8bc1b417"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Return Output",
             "description": null,
             "arguments": {
@@ -464,28 +486,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "c51caa0e-fe0c-4e01-9992-220317e48209"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set CICD Config Global Variable",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "macro": "{{\"cicd_config\"}}",
-                    "value": "{{ ({\"source_control_web_url\": vars.source_control_base_url,\"organizationName\": vars.organization_name, \"content\": vars.content_repo, \"productionSettings\": vars.prod_settings, \"developmentSettings\": vars.dev_settings, \"baseBranch\": vars.base_branch,\"contentRepoName\": vars.steps.Get_Repositories_Detail.input.contentRepositoryName, \"prodSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName, \"devSettingsRepoName\": vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}) | toJSON }}"
-                },
-                "version": "3.3.0",
-                "connector": "cyops_utilities",
-                "operation": "updatemacro",
-                "operationTitle": "FSR: Create\/Update Global Variables",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1400",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "c9c6876f-56ec-464f-8759-e95de2d4d663"
         },
         {
             "@type": "WorkflowStep",
@@ -537,6 +537,37 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "990ef5b3-56a4-4aa7-bd2d-9acb3b444e71"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Source Control Settings Config",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "configurationParameters": {
+                        "baseBranch": "{{vars.steps.Get_Repositories_Detail.input.baseBranchName}}",
+                        "contentRepoName": "{{vars.steps.Get_Repositories_Detail.input.contentRepositoryName}}",
+                        "organizationName": "{{vars.steps.Get_Repositories_Detail.input.orgName}}",
+                        "source_control_url": "{{vars.source_control_base_url}}",
+                        "devSettingsRepoName": "{{vars.steps.Get_Repositories_Detail.input.developmentSettingsRepositoryName}}",
+                        "prodSettingsRepoName": "{{vars.steps.Get_Repositories_Detail.input.productionSettingsRepositoryName}}"
+                    }
+                },
+                "operation": "Append",
+                "collection": "{{vars.steps.Find_Source_Control_Settings[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1420",
+            "left": "120",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "9f621f13-3f19-4caa-b9b6-cb84d45bbfc4"
         },
         {
             "@type": "WorkflowStep",
@@ -661,13 +692,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Base Branch Latest Commit -> Repository Details",
-            "targetStep": "\/api\/3\/workflow_steps\/56935f57-cf06-487f-8d0d-97ae8bc1b417",
+            "name": "Find Source Control Settings -> Update Source Control Settings Config",
+            "targetStep": "\/api\/3\/workflow_steps\/9f621f13-3f19-4caa-b9b6-cb84d45bbfc4",
+            "sourceStep": "\/api\/3\/workflow_steps\/f8834aec-b964-4df6-99f6-35167ccff85e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "39929ef9-bdd0-412d-8e75-ff53e22ce70f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Base Branch Latest Commit -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/f8834aec-b964-4df6-99f6-35167ccff85e",
             "sourceStep": "\/api\/3\/workflow_steps\/fe6d5d55-94fd-4863-962c-767d46e9fdbd",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "d722115f-fdae-46dd-92d2-86abb8c918aa"
+            "uuid": "127eb0f5-1844-46b3-8856-1862029a5bd0"
         },
         {
             "@type": "WorkflowRoute",
@@ -731,26 +772,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Repository Details -> Set CICD Config Global Variable",
-            "targetStep": "\/api\/3\/workflow_steps\/c9c6876f-56ec-464f-8759-e95de2d4d663",
-            "sourceStep": "\/api\/3\/workflow_steps\/56935f57-cf06-487f-8d0d-97ae8bc1b417",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "b7978088-2a8a-411d-a96b-150117aaf017"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Set CICD Config Global Variable -> Find Previous Result",
-            "targetStep": "\/api\/3\/workflow_steps\/66f26ebf-cfbb-4678-94f7-a64d94f2827f",
-            "sourceStep": "\/api\/3\/workflow_steps\/c9c6876f-56ec-464f-8759-e95de2d4d663",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "1634611d-5895-47a6-8f97-773c40dc5cba"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Start -> Get Source Control Details",
             "targetStep": "\/api\/3\/workflow_steps\/f8a73194-eca6-4b60-a614-3da740ad9667",
             "sourceStep": "\/api\/3\/workflow_steps\/601f718e-64a7-4e5f-a022-dac1423b613f",
@@ -768,6 +789,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "6c14084e-0dce-4c80-ab84-17f8741d94c2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Source Control Settings Config -> Find Previous Result",
+            "targetStep": "\/api\/3\/workflow_steps\/66f26ebf-cfbb-4678-94f7-a64d94f2827f",
+            "sourceStep": "\/api\/3\/workflow_steps\/9f621f13-3f19-4caa-b9b6-cb84d45bbfc4",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7b5c392f-78c3-43bb-8fa4-d89cf07c555f"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Create Pull Request.json
+++ b/playbooks/02 - Use Case - CICD/Create Pull Request.json
@@ -38,8 +38,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2120",
-            "left": "120",
+            "top": "2190",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "4856e43d-b973-4da9-b2ca-cded60b2bc74"
@@ -67,8 +67,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2060",
-            "left": "820",
+            "top": "2190",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "66ef50d9-47db-4796-adb0-8c79f8098d13"
@@ -89,7 +89,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"PullRequestAddReviewers\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1920",
+            "top": "2055",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -143,11 +143,11 @@
                 "cicd_env": "{{globalVars.cicd_env}}",
                 "issue_no": "{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
                 "repo_name": "{{(vars.input.records[0].repo_url.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
-                "cicdConfig": "{{globalVars.cicd_config | toDict}}",
+                "cicdConfig": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}",
                 "new_branch": "CR-{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}"
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -169,7 +169,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateIssueComment\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1785",
+            "top": "1920",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -192,7 +192,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreatePullRequest\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1650",
+            "top": "1785",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -237,13 +237,64 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "afe0686a-8975-4774-a25b-decfa07e7deb"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Get All PR Reviewers",
             "description": null,
             "arguments": {
                 "pr_reviewers": "{% set login = [] %}{% for item in vars.steps.Get_Repo_Collaborators.data %}{% if (item.permissions.push or item.permissions.admin or item.permissions.maintain) and (vars.steps.Get_FSR_Current_User.data.sourceControlUsername != item.login) %}{% set _ = login.append(item.login) %}{% endif %}{% endfor %}{{login}}"
             },
             "status": null,
-            "top": "1110",
+            "top": "1245",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -266,7 +317,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -290,7 +341,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetPullRequest\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1380",
+            "top": "1515",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -313,7 +364,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"ListRepositoryCollaborator\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -334,8 +385,8 @@
                     {
                         "option": "Finished",
                         "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/75987958-0371-463d-8160-6d25120a9711",
-                        "step_name": "Configuration"
+                        "step_iri": "\/api\/3\/workflow_steps\/afe0686a-8975-4774-a25b-decfa07e7deb",
+                        "step_name": "Find Source Control Settings"
                     }
                 ],
                 "step_variables": []
@@ -356,7 +407,7 @@
                     {
                         "option": "PR Already Exist",
                         "step_iri": "\/api\/3\/workflow_steps\/d59a0290-218d-4e2b-aa6f-784ef77b839e",
-                        "condition": "{{ (vars.steps.Get_Pull_Request.data | json_query(\"[?head.ref == '\"+vars.input.records[0].new_branch+\"']\")) | length == 1 }}",
+                        "condition": "{{ (vars.steps.Get_Pull_Request.data | length > 0) and (vars.steps.Get_Pull_Request.data | json_query(\"[?head.ref == '\"+vars.input.records[0].new_branch+\"']\")) | length == 1 }}",
                         "step_name": "PR Already Exist"
                     },
                     {
@@ -368,14 +419,14 @@
                     {
                         "option": "No Commits",
                         "step_iri": "\/api\/3\/workflow_steps\/0a9e48e7-7e6c-419b-afff-e4a452c5f896",
-                        "condition": "{{ (vars.steps.Get_Pull_Request.data | json_query(\"[?head.ref == '\"+vars.input.records[0].new_branch+\"']\")) | length == 0 }}",
+                        "condition": "{{ (vars.steps.Get_Pull_Request.data | length > 0) and (vars.steps.Get_Pull_Request.data | json_query(\"[?head.ref == '\"+vars.input.records[0].new_branch+\"']\")) | length == 0 }}",
                         "step_name": "No Commits Available"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "1650",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -404,8 +455,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2060",
-            "left": "1120",
+            "top": "2190",
+            "left": "1175",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "0a9e48e7-7e6c-419b-afff-e4a452c5f896"
@@ -432,8 +483,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2220",
-            "left": "820",
+            "top": "2325",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "3089fac2-3c2a-43d9-871e-621889d80784"
@@ -461,8 +512,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2060",
-            "left": "520",
+            "top": "2190",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "d59a0290-218d-4e2b-aa6f-784ef77b839e"
@@ -556,7 +607,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "1245",
+            "top": "1380",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -724,6 +775,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/75987958-0371-463d-8160-6d25120a9711",
+            "sourceStep": "\/api\/3\/workflow_steps\/afe0686a-8975-4774-a25b-decfa07e7deb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1b91e6ea-f4c1-4e18-ba0d-7f6f93359bbe"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get All PR Reviewers -> Specify PR Title and Comments",
             "targetStep": "\/api\/3\/workflow_steps\/2b0bec0a-3363-46c6-96d7-da2756f7924a",
             "sourceStep": "\/api\/3\/workflow_steps\/4907717f-62d4-4f8e-9072-7f99b40a964d",
@@ -774,13 +835,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Playbook Active or Awaiting -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/75987958-0371-463d-8160-6d25120a9711",
+            "name": "Is Playbook Active or Awaiting -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/afe0686a-8975-4774-a25b-decfa07e7deb",
             "sourceStep": "\/api\/3\/workflow_steps\/3f55b0ad-6d3d-45ca-8412-f5458ad56c4a",
             "label": "Finished",
             "isExecuted": false,
             "group": null,
-            "uuid": "cc55a7d2-b32c-41c3-9a40-2c3c32a435e6"
+            "uuid": "e62eb823-69f6-47c6-89a9-3601a815d213"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Create Release.json
+++ b/playbooks/02 - Use Case - CICD/Create Release.json
@@ -21,13 +21,13 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Add comment for existing release",
+            "name": "Add Existing Release Comment",
             "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "people": [],
-                    "content": "<p>The release <a href=\"{{vars.steps.Fetch_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Fetch_Release.data.name}}<\/a> already exist for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}<\/a> Repository.<\/p>",
+                    "content": "<p>The release <a href=\"{{vars.steps.Fetch_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Fetch_Release.data.name}}<\/a> already exist for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}<\/a> Repository.<\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false,
@@ -42,21 +42,21 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "980",
-            "left": "120",
+            "top": "1110",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "87e28c72-85e0-48f8-ae2b-d11d659cf9d6"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Add comment for new release",
+            "name": "Add New Release Comment",
             "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "people": [],
-                    "content": "<p>A new release &nbsp;<a href=\"{{vars.steps.Create_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Create_Release.data.name}}<\/a> is successfully created for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}<\/a> repository<\/p>",
+                    "content": "<p>A new release &nbsp;<a rel=\"noopener\" target=\"_blank\" href=\"{{vars.steps.Create_Release.data['html_url']}}\">{{vars.steps.Create_Release.data.name}}<\/a> is successfully created for the <a rel=\"noopener\" target=\"_blank\" href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}\">{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}<\/a> repository.<\/p>",
                     "__replace": "",
                     "isImportant": false,
                     "peopleUpdated": false,
@@ -71,11 +71,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "980",
-            "left": "480",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
-            "uuid": "153d8ce3-45f9-4a9d-9bb1-b7f092551aa4"
+            "uuid": "431e6201-fce2-436d-9878-6920520381e4"
         },
         {
             "@type": "WorkflowStep",
@@ -83,16 +83,16 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{(globalVars.cicd_config | toDict)}}",
+                "cicd_config": "{{vars.cicd_config}}",
                 "release_name": "Release\/",
                 "release_number": "1.0",
-                "source_control_web_url": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"]}}",
+                "source_control_web_url": "{{vars.cicd_config.source_control_url}}",
                 "prod_environment_record_iri": "\/api\/3\/change_management\/4be084b9-c5fe-4d42-943f-6bb2161d7157",
                 "release_initial_description": "Intial Commit",
                 "development_environment_record_uuid": "\/api\/3\/change_management\/acae4646-2b5b-4e4c-9f7f-9a4d47d93d47"
             },
             "status": null,
-            "top": "160",
+            "top": "300",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -105,7 +105,7 @@
             "arguments": {
                 "arguments": {
                     "connector_config_id": "{{vars.input.params['connector_config_id']}}",
-                    "create_release_params": "{\n\"org_name\": \"{{vars.cicd_config.content.split('\/')[-2]}}\",\n\"repo_name\": \"{{vars.cicd_config.content.split('\/')[-1]}}\",\n\"base_branch\": \"{{vars.cicd_config.baseBranch}}\",\n\"release_description\": \"{{vars.input.params['release_description']| ternary(vars.input.params['release_description'], vars.release_initial_description)}}\",\n\"tag_name\": \"{{vars.release_name}}{{vars.input.params['release_number']| ternary(vars.input.params['release_number'], vars.release_number)}}\"\n}"
+                    "create_release_params": "{\n\"org_name\": \"{{vars.cicd_config.organizationName}}\",\n\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\n\"base_branch\": \"{{vars.cicd_config.baseBranch}}\",\n\"release_description\": \"{{vars.input.params['release_description']| ternary(vars.input.params['release_description'], vars.release_initial_description)}}\",\n\"tag_name\": \"{{vars.release_name}}{{vars.input.params['release_number']| ternary(vars.input.params['release_number'], vars.release_number)}}\"\n}"
                 },
                 "apply_async": false,
                 "step_variables": {
@@ -116,8 +116,8 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateRelease\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "840",
-            "left": "480",
+            "top": "975",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "93e3d5a7-bfbb-4b08-bd2e-4890c7cf1f7b"
@@ -129,7 +129,7 @@
             "arguments": {
                 "arguments": {
                     "connector_config_id": "{{vars.input.params['connector_config_id']}}",
-                    "fetch_release_params": "{\n\"org_name\": \"{{vars.cicd_config.content.split('\/')[-2]}}\",\n\"repo_name\": \"{{vars.cicd_config.content.split('\/')[-1]}}\",\n\"release_name\": \"{{vars.release_name}}{{vars.release_number}}\"\n}"
+                    "fetch_release_params": "{\n\"org_name\": \"{{vars.cicd_config.organizationName}}\",\n\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\n\"release_name\": \"{{vars.release_name}}{{vars.release_number}}\"\n}"
                 },
                 "apply_async": false,
                 "ignore_errors": false,
@@ -139,7 +139,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"FetchRelease\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "560",
+            "top": "705",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -183,7 +183,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -216,11 +216,56 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "440",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "9d6e356e-d929-444d-ae85-e6f463f2a18b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "environment",
+                            "value": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                                "itemValue": "Production"
+                            },
+                            "operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{{vars.steps.Find_Source_Control_Settings[0].configurationParameters}}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "d82cbad2-c92e-41ca-bd38-d1466e2020bb"
         },
         {
             "@type": "WorkflowStep",
@@ -243,7 +288,7 @@
                 ]
             },
             "status": null,
-            "top": "700",
+            "top": "840",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -273,17 +318,19 @@
             "description": null,
             "arguments": {
                 "resource": {
-                    "results": "<p>{% if vars.input.records[0].title != \"Apply Latest Content\" %}{{vars.steps.Find_Previous_Result[0].results}}{%endif%}<\/p>\n<p>&nbsp;<\/p>\n<p class=\"mp-tile-description muted-80\"><strong>- Release<\/strong><\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Fetch_Release.data | length == 0 %}A new release &nbsp;<a href=\"{{vars.steps.Create_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Create_Release.data.name}}<\/a> is successfully created for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}<\/a> Repository.{%else %}<\/p>\n<p class=\"mp-tile-description muted-80\">The release <a href=\"{{vars.steps.Fetch_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Fetch_Release.data.name}}<\/a> already exist for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.content.split('\/')[-2]}}\/{{vars.cicd_config.content.split('\/')[-1]}}<\/a> Repository.{%endif%}<\/p>"
+                    "results": "<p>{% if vars.input.records[0].title != \"Apply Latest Content\" %}{{vars.steps.Find_Previous_Result[0].results}}{%endif%}<\/p>\n<p>&nbsp;<\/p>\n<p class=\"mp-tile-description muted-80\"><strong>- Release<\/strong><\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Fetch_Release.data | length == 0 %}A new release &nbsp;<a href=\"{{vars.steps.Create_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Create_Release.data.name}}<\/a> is successfully created for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}<\/a> Repository.{%else %}<\/p>\n<p class=\"mp-tile-description muted-80\">The release <a href=\"{{vars.steps.Fetch_Release.data['html_url']}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Fetch_Release.data.name}}<\/a> already exist for the <a href=\"{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}\" target=\"_blank\" rel=\"noopener\">{{vars.source_control_web_url}}\/{{vars.cicd_config.organizationName}}\/{{vars.cicd_config.contentRepoName}}<\/a> Repository.{%endif%}<\/p>"
                 },
                 "operation": "Append",
                 "collection": "{{vars.input.records[0]['@id']}}",
                 "__recommend": [],
                 "collectionType": "\/api\/3\/change_management",
-                "fieldOperation": [],
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
                 "step_variables": []
             },
             "status": null,
-            "top": "1100",
+            "top": "1245",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -303,13 +350,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Add comment for new release -> Update Record",
+            "name": "Add New Release -> Update Record",
             "targetStep": "\/api\/3\/workflow_steps\/cbb514f9-802a-46e8-9120-40592bab4f24",
-            "sourceStep": "\/api\/3\/workflow_steps\/153d8ce3-45f9-4a9d-9bb1-b7f092551aa4",
+            "sourceStep": "\/api\/3\/workflow_steps\/431e6201-fce2-436d-9878-6920520381e4",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "d77b6df5-d704-471f-862f-3c0937ddfd8d"
+            "uuid": "61d9cd1b-3e02-4d2b-ac60-62465957fdc0"
         },
         {
             "@type": "WorkflowRoute",
@@ -323,13 +370,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Create Release -> Add comment for new release",
-            "targetStep": "\/api\/3\/workflow_steps\/153d8ce3-45f9-4a9d-9bb1-b7f092551aa4",
+            "name": "Create Release -> Add New Release",
+            "targetStep": "\/api\/3\/workflow_steps\/431e6201-fce2-436d-9878-6920520381e4",
             "sourceStep": "\/api\/3\/workflow_steps\/93e3d5a7-bfbb-4b08-bd2e-4890c7cf1f7b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "a73a17de-7911-4787-a8b8-4e6d4516b9c8"
+            "uuid": "5718b99d-0dcc-4db8-af92-457db239eb1c"
         },
         {
             "@type": "WorkflowRoute",
@@ -363,6 +410,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/88629062-0a07-4f0c-8b2e-204b651b6af4",
+            "sourceStep": "\/api\/3\/workflow_steps\/d82cbad2-c92e-41ca-bd38-d1466e2020bb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "dc2379d9-eac7-41be-af85-0edf8bab09a7"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Is Release Exist -> Add comment for existing release",
             "targetStep": "\/api\/3\/workflow_steps\/87e28c72-85e0-48f8-ae2b-d11d659cf9d6",
             "sourceStep": "\/api\/3\/workflow_steps\/a30e6ec7-8628-450d-a612-992c6ca026e9",
@@ -383,13 +440,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/88629062-0a07-4f0c-8b2e-204b651b6af4",
+            "name": "Start -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/d82cbad2-c92e-41ca-bd38-d1466e2020bb",
             "sourceStep": "\/api\/3\/workflow_steps\/48c3020d-e1a4-4960-91ae-1a0591836ead",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "24d3ba3f-a24e-4f9f-a420-95f26340ac5c"
+            "uuid": "71516e88-21c3-445d-a6dd-fc0628d0634f"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
+++ b/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
@@ -23,7 +23,6 @@
                 "arguments": [],
                 "apply_async": false,
                 "step_variables": {
-                    "cicd_config": "{{globalVars.cicd_config}}",
                     "USER_MAPPING": "{% set user_mapping = {} %}{% for user in vars.steps.Get_Users.data['hydra:member'] %}{% if user['sourceControlUsername'] != None %}{% set _=user_mapping.update({user.firstname + \" \"+ (user.lastname or \"\") : user.sourceControlUsername }) %}{% endif %}{% endfor %}{{user_mapping}}"
                 },
                 "pass_parent_env": false,
@@ -32,7 +31,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "85cba27a-af44-4e37-a0c9-9fddf9598f16"
@@ -43,12 +42,12 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "repo_name": "{{vars.cicd_config.content.split('\/')[-1]}}",
+                "repo_name": "{{vars.cicd_config.contentRepoName}}",
                 "assigneeUsername": "{{vars.USER_MAPPING.get(vars.steps.Get_Change_Request_Details.input.assignee)}}"
             },
             "status": null,
-            "top": "570",
-            "left": "125",
+            "top": "705",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "20429145-4b50-4df0-a0c8-cde5d66ccd7e"
@@ -70,8 +69,8 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateBranch\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "840",
-            "left": "125",
+            "top": "975",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "ef404be3-62aa-4dac-8a59-e8caa1db9eb7"
@@ -94,8 +93,8 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CreateIssue\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "705",
-            "left": "125",
+            "top": "840",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "142799f7-839a-4e01-b9a1-962a8d7a826d"
@@ -123,10 +122,62 @@
             },
             "status": null,
             "top": "570",
-            "left": "475",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "04cff439-8526-4426-9ddb-e1d06a942dc3"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{{vars.steps.Find_Source_Control_Settings[0].configurationParameters}}"
+                }
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "0d2f7957-7c7b-42df-87b6-d68b1a0f01d9"
         },
         {
             "@type": "WorkflowStep",
@@ -267,7 +318,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "475",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "1e550c25-0714-436d-bbf1-d5b6ba376506"
@@ -337,13 +388,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/20429145-4b50-4df0-a0c8-cde5d66ccd7e",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/0d2f7957-7c7b-42df-87b6-d68b1a0f01d9",
             "sourceStep": "\/api\/3\/workflow_steps\/85cba27a-af44-4e37-a0c9-9fddf9598f16",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "30900906-21f1-4586-8283-c2612c84e1f1"
+            "uuid": "d6627cab-8cf3-41ae-9b7e-e5680db2bac1"
         },
         {
             "@type": "WorkflowRoute",
@@ -364,6 +415,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "8663eaf3-765e-444b-8973-7c5d62678ea7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/20429145-4b50-4df0-a0c8-cde5d66ccd7e",
+            "sourceStep": "\/api\/3\/workflow_steps\/0d2f7957-7c7b-42df-87b6-d68b1a0f01d9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "dae5bd1f-34cf-45dc-927c-31aa564791dd"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Evaluate Git Sync Drift.json
+++ b/playbooks/02 - Use Case - CICD/Evaluate Git Sync Drift.json
@@ -47,12 +47,12 @@
             "arguments": {
                 "cr_iri": "{{vars.input.records[0]['@id'] or vars.input.params['cr_iri']}}",
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{globalVars.cicd_config}}",
+                "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}",
                 "lastCommitID": "{{vars.input.records[0].lastCommitID or vars.input.params.lastCommitID}}",
                 "previousCommitID": "{{vars.previous.data.lastCommitID or vars.input.params.previousCommitID}}"
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -64,7 +64,7 @@
             "description": null,
             "arguments": {
                 "arguments": {
-                    "get_commit_params": "{\n\"org_name\": \"{{vars.cicd_config. organizationName}}\",\n\"repo_name\": \"{{vars.cicd_config. contentRepoName}}\",\n\"base\": \"{{vars.lastCommitID}}\",\n\"head\": \"{{vars.previousCommitID}}\"\n}",
+                    "get_commit_params": "{\n\"org_name\": \"{{vars.cicd_config.organizationName}}\",\n\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\n\"base\": \"{{vars.lastCommitID}}\",\n\"head\": \"{{vars.previousCommitID}}\"\n}",
                     "connector_config_id": "aaa"
                 },
                 "apply_async": false,
@@ -76,39 +76,62 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetCommitComparison\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "570",
-            "left": "135",
+            "top": "705",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "805ac11c-d049-4494-af2e-c69070685c3c"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Is Last Commit Behind",
+            "name": "Find Source Control Settings",
             "description": null,
             "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/9f775b6c-5b85-4586-8ff9-cb0d4dcfad2c",
-                        "condition": "{{ vars.steps.Fetch_Commit_Comparison.data.status == \"behind\" }}",
-                        "step_name": "Send Notification"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/d1b9d28d-a5f0-4b59-b569-f80e068cf754",
-                        "step_name": "No Operation"
-                    }
-                ],
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "135",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
-            "uuid": "434fee56-88e6-4e8a-933d-89298bbb9d65"
+            "uuid": "bcf4a52c-9cdb-4e21-afe3-5bd5401b7054"
         },
         {
             "@type": "WorkflowStep",
@@ -132,7 +155,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -151,65 +174,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "705",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "d1b9d28d-a5f0-4b59-b569-f80e068cf754"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Send Notification",
-            "description": null,
-            "arguments": {
-                "type": "InputBased",
-                "input": {
-                    "schema": {
-                        "title": "Sync Required: Environment Behind",
-                        "description": "<h4 style=\"color: #ff9900;\">\u26a0\ufe0f Environment Drift Detected<\/h4>\n<p>This environment is currently&nbsp;<strong>{{ vars.steps.Fetch_Commit_Comparison.data.behind_by }} commit(s) behind<\/strong> the latest production content.<\/p>\n<p>To bring this environment <strong>up-to-date<\/strong>, apply the latest production content.<\/p>\n<br>\n\n**Environment Drift Report**\n* Status: {{ vars.steps.Fetch_Commit_Comparison.data.status }}\n* Ahead By: {{ vars.steps.Fetch_Commit_Comparison.data.ahead_by }}\n* Behind By: {{ vars.steps.Fetch_Commit_Comparison.data.behind_by }}\n* Total Commits Difference: {{ vars.steps.Fetch_Commit_Comparison.data.total_commits }}\n* Comparison: [View Comparison]({{vars.comparisonLink}})",
-                        "inputVariables": []
-                    }
-                },
-                "record": "{{vars.cr_iri}}",
-                "agent_id": null,
-                "resources": "change_management",
-                "is_approval": false,
-                "owner_detail": {
-                    "isAssigned": false,
-                    "emailRecipients": ""
-                },
-                "isRecordLinked": true,
-                "step_variables": [],
-                "response_mapping": {
-                    "options": [
-                        {
-                            "option": "Ok",
-                            "primary": true,
-                            "step_iri": "\/api\/3\/workflow_steps\/d1b9d28d-a5f0-4b59-b569-f80e068cf754"
-                        }
-                    ],
-                    "duplicateOption": false,
-                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
-                },
-                "email_notification": {
-                    "enabled": false,
-                    "smtpParameters": []
-                },
-                "customEmailExternal": false,
-                "inline_channel_list": [],
-                "external_channel_list": [],
-                "unauthenticated_input": false,
-                "external_email_subject": null,
-                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
-                "custom_email_body_external": null,
-                "external_email_attachments": null
-            },
-            "status": null,
-            "top": "975",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
-            "group": null,
-            "uuid": "9f775b6c-5b85-4586-8ff9-cb0d4dcfad2c"
         },
         {
             "@type": "WorkflowStep",
@@ -289,8 +258,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
-            "left": "135",
+            "top": "840",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "240a6220-7993-4a2e-b06f-6fd6ad2407af"
@@ -299,13 +268,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/8b0637f2-0293-4cae-b468-1566a8b17b1c",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/bcf4a52c-9cdb-4e21-afe3-5bd5401b7054",
             "sourceStep": "\/api\/3\/workflow_steps\/162fb2f9-c370-4559-bc37-025ea8ad7fd3",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "10049dce-f02a-4e7c-b09b-226a98bdafda"
+            "uuid": "b96fe69a-6e34-46a1-8448-69599a1fed35"
         },
         {
             "@type": "WorkflowRoute",
@@ -329,23 +298,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Last Commit Behind -> No Operation",
-            "targetStep": "\/api\/3\/workflow_steps\/d1b9d28d-a5f0-4b59-b569-f80e068cf754",
-            "sourceStep": "\/api\/3\/workflow_steps\/434fee56-88e6-4e8a-933d-89298bbb9d65",
-            "label": "No",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/8b0637f2-0293-4cae-b468-1566a8b17b1c",
+            "sourceStep": "\/api\/3\/workflow_steps\/bcf4a52c-9cdb-4e21-afe3-5bd5401b7054",
+            "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "f85f7a85-2246-43e1-a7ca-955758275a1a"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is Last Commit Behind -> Send Notification",
-            "targetStep": "\/api\/3\/workflow_steps\/9f775b6c-5b85-4586-8ff9-cb0d4dcfad2c",
-            "sourceStep": "\/api\/3\/workflow_steps\/434fee56-88e6-4e8a-933d-89298bbb9d65",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "c29f87fa-8415-4b7f-b3e3-201c9a0be6ae"
+            "uuid": "fbefd2fc-1afe-4d4e-a944-7ca7db235c04"
         },
         {
             "@type": "WorkflowRoute",
@@ -376,16 +335,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "a5324915-ecb0-4300-8e7e-79723daae76c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Record -> Is Last Commit Behind",
-            "targetStep": "\/api\/3\/workflow_steps\/434fee56-88e6-4e8a-933d-89298bbb9d65",
-            "sourceStep": "\/api\/3\/workflow_steps\/240a6220-7993-4a2e-b06f-6fd6ad2407af",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "37ee36e1-d959-47d2-8926-dc772c8659b3"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Fetch Closed Requests (Issues).json
+++ b/playbooks/02 - Use Case - CICD/Fetch Closed Requests (Issues).json
@@ -33,7 +33,8 @@
                         "step_iri": "\/api\/3\/workflow_steps\/cea03472-0e68-4c83-a4ff-3863e1eca790",
                         "step_name": "Return Blank Output"
                     }
-                ]
+                ],
+                "step_variables": []
             },
             "status": null,
             "top": "435",
@@ -119,6 +120,59 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "284ffc6f-7a8f-403d-b098-a14a4a72bc52"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Get Issues",
             "description": null,
             "arguments": {
@@ -138,31 +192,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "237277ee-619e-4bc1-b13f-0896b08fd68f"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name=cicd_config",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "cicd_config": "{% if vars.result.data['hydra:member'] | length %}{{vars.result.data['hydra:member'][0].value | toDict }}{% else %}\"\"{% endif %}"
-                }
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "bb6ff9c7-9475-4f82-ae86-fa127dfb212e"
         },
         {
             "@type": "WorkflowStep",
@@ -289,13 +318,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/bb6ff9c7-9475-4f82-ae86-fa127dfb212e",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/284ffc6f-7a8f-403d-b098-a14a4a72bc52",
             "sourceStep": "\/api\/3\/workflow_steps\/4839ee2b-c6ff-4cbd-bba8-a78b7abeb80b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "ae5c75d6-93ce-4961-a313-d0265e8367e8"
+            "uuid": "6ddc9775-0ba3-4af4-b1d7-127887ff6e4f"
         },
         {
             "@type": "WorkflowRoute",
@@ -309,16 +338,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Get Source Control Details -> Has Repositories Created",
-            "targetStep": "\/api\/3\/workflow_steps\/7c87795f-4b9e-4a38-ba4b-7cfa6dfb1475",
-            "sourceStep": "\/api\/3\/workflow_steps\/bb6ff9c7-9475-4f82-ae86-fa127dfb212e",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "7b33b382-6a80-47fb-b544-4c436583ce0a"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Find Apply Latest Change Record -> Get Issues",
             "targetStep": "\/api\/3\/workflow_steps\/237277ee-619e-4bc1-b13f-0896b08fd68f",
             "sourceStep": "\/api\/3\/workflow_steps\/c66e0195-90a1-4212-b17e-79de54c6bce6",
@@ -326,6 +345,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "83f90574-9cb9-4c58-aa16-173961dd38d0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Are Repositories Created",
+            "targetStep": "\/api\/3\/workflow_steps\/7c87795f-4b9e-4a38-ba4b-7cfa6dfb1475",
+            "sourceStep": "\/api\/3\/workflow_steps\/284ffc6f-7a8f-403d-b098-a14a4a72bc52",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7fb07b65-7833-4a32-9909-a69bb48031f3"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Fetch Open Requests (Issues).json
+++ b/playbooks/02 - Use Case - CICD/Fetch Open Requests (Issues).json
@@ -33,7 +33,8 @@
                         "step_iri": "\/api\/3\/workflow_steps\/c3459965-6b06-40fe-8129-997bbd8b9c5b",
                         "step_name": "Return Blank Output"
                     }
-                ]
+                ],
+                "step_variables": []
             },
             "status": null,
             "top": "435",
@@ -75,6 +76,59 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "deae7f44-95e7-47c6-bdb1-d23c5b1b0957"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "c140578c-b082-47b6-9ca6-5554765648d9"
         },
         {
             "@type": "WorkflowStep",
@@ -135,31 +189,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "869c391c-fcff-4aae-81bb-9d52f5560786"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name=cicd_config",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "cicd_config": "{% if vars.result.data['hydra:member'] | length %}{{vars.result.data['hydra:member'][0].value | toDict }}{% else %}\"\"{% endif %}"
-                }
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "e190db03-961f-485f-a70d-91c88556cad4"
         },
         {
             "@type": "WorkflowStep",
@@ -272,13 +301,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/e190db03-961f-485f-a70d-91c88556cad4",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/c140578c-b082-47b6-9ca6-5554765648d9",
             "sourceStep": "\/api\/3\/workflow_steps\/a05e66b1-4d8e-4112-baf4-b4fe9e4a50a3",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e63b3cd1-cdd7-43e4-bb00-db28b5d93e16"
+            "uuid": "e1e32dfa-9bb3-415c-82ec-52e7dfcde04b"
         },
         {
             "@type": "WorkflowRoute",
@@ -302,13 +331,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Get Source Control Details -> Has Repositories Created",
+            "name": "Find Source Control Settings -> Are Repositories Created",
             "targetStep": "\/api\/3\/workflow_steps\/4073de99-9d80-45f9-84ac-6062a4ff3649",
-            "sourceStep": "\/api\/3\/workflow_steps\/e190db03-961f-485f-a70d-91c88556cad4",
+            "sourceStep": "\/api\/3\/workflow_steps\/c140578c-b082-47b6-9ca6-5554765648d9",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e09e6e4a-af27-4466-82ff-efcd40eeab8b"
+            "uuid": "b7d39421-776c-489f-a967-a42a8ae93c70"
         },
         {
             "@type": "WorkflowRoute",
@@ -384,7 +413,7 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "22ddd2f3-b2e5-4465-b8b8-86ca8a276a6a",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
@@ -17,15 +17,65 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Configuration",
+            "name": "Get All FSR Users",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/3\/people?$limit=2147483647&$orderby=%2Bfirstname,%2Blastname,-modifyDate&&__selectFields=userId",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.6.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "userId": "{{vars.steps.Get_All_FSR_Users.data[\"hydra:member\"] | selectattr(\"@type\", \"equalto\", \"Person\") | map(attribute=\"userId\") | list}}"
+                }
+            },
+            "status": null,
+            "top": "460",
+            "left": "620",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b336e79a-0f1c-4c3d-9383-a84ed923299e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get All FSR Users Auth",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/auth\/query\/users",
+                    "body": "{ \"users\":{{vars.userId}} }",
+                    "method": "POST"
+                },
+                "version": "3.6.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "logged_in_user_iri": "{% set uuid = (vars.steps.Get_All_FSR_Users_Auth.data.usersresp | selectattr(\"is_logged_in\", \"equalto\", true) | map(attribute=\"uuid\") | list)[0] %}{% set matched_users = vars.steps.Get_All_FSR_Users.data['hydra:member'] | selectattr(\"userId\", \"equalto\", uuid) | list %}{{ matched_users[0]['@id'] if matched_users else 'User not found' }}"
+                }
+            },
+            "status": null,
+            "top": "580",
+            "left": "620",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "b6b0f6c8-0111-4786-9d2b-c9819b5c294a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Current User Configuration",
             "description": null,
             "arguments": {
                 "current_user_source_control_connector_username": "{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name==connector_config.config.username %}{{connector_config.config.username}}{% break %}{% endif %}{% endfor %}",
                 "current_user_source_control_connector_config_id": "{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name==connector_config.config.username %}{{connector_config.config_id}}{% break %}{% endif %}{% endfor %}"
             },
             "status": null,
-            "top": "435",
-            "left": "135",
+            "top": "840",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "2c4669a5-feca-4025-98f9-190c4ac2020c"
@@ -77,8 +127,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
-            "left": "135",
+            "top": "975",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "1b057294-590b-4a4d-b951-7b455c52c426"
@@ -92,14 +142,14 @@
                     {
                         "option": "Yes",
                         "step_iri": "\/api\/3\/workflow_steps\/2c4669a5-feca-4025-98f9-190c4ac2020c",
-                        "condition": "{{ vars.logged_in_user_sc_name != None }}",
-                        "step_name": "Configuration"
+                        "condition": "{{ vars.logged_in_user_sc_name | length > 0 and vars.logged_in_user_sc_name != None }}",
+                        "step_name": "Get Current User Configuration"
                     },
                     {
                         "option": "No",
                         "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/5803d81b-20a4-493d-864e-eb45d78c3b13",
-                        "step_name": "Update Status"
+                        "step_iri": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
+                        "step_name": "Get All FSR Users"
                     }
                 ],
                 "step_variables": []
@@ -110,6 +160,20 @@
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "acc75bf1-5995-4f46-91db-151f6cc751ef"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Loggedin User Details",
+            "description": null,
+            "arguments": {
+                "logged_in_user_sc_name": "{{(vars.logged_in_user_iri | fromIRI).sourceControlUsername }}"
+            },
+            "status": null,
+            "top": "720",
+            "left": "620",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "283d973a-f3b8-4b62-aab6-ef2d7e669b70"
         },
         {
             "@type": "WorkflowStep",
@@ -127,7 +191,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1245",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -142,7 +206,7 @@
                 "source_control_username": "{{vars.current_user_source_control_connector_username}}"
             },
             "status": null,
-            "top": "705",
+            "top": "1110",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -187,7 +251,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -204,6 +268,26 @@
             "isExecuted": false,
             "group": null,
             "uuid": "ce1c50fc-06a9-4559-b563-ed7f04780824"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get All FSR Users Auth -> Loggedin User Details",
+            "targetStep": "\/api\/3\/workflow_steps\/283d973a-f3b8-4b62-aab6-ef2d7e669b70",
+            "sourceStep": "\/api\/3\/workflow_steps\/b6b0f6c8-0111-4786-9d2b-c9819b5c294a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ecc7cd8e-f9c9-4095-baf7-0ae69f0f16a3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get All FSR Users -> Copy of Get All FSR Users",
+            "targetStep": "\/api\/3\/workflow_steps\/b6b0f6c8-0111-4786-9d2b-c9819b5c294a",
+            "sourceStep": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3720e697-42a3-4804-9ced-255da5f59e8b"
         },
         {
             "@type": "WorkflowRoute",
@@ -233,7 +317,7 @@
             "label": "No",
             "isExecuted": false,
             "group": null,
-            "uuid": "96e22fb7-7e09-4e39-9569-6024acc2e34b"
+            "uuid": "317e2011-7389-4a34-b701-f8b9b32b8254"
         },
         {
             "@type": "WorkflowRoute",
@@ -247,13 +331,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is FSR Logged in Username Mapped -> Update Status",
-            "targetStep": "\/api\/3\/workflow_steps\/5803d81b-20a4-493d-864e-eb45d78c3b13",
+            "name": "Is FSR Logged in Username Mapped -> Get All FSR Users",
+            "targetStep": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
             "sourceStep": "\/api\/3\/workflow_steps\/acc75bf1-5995-4f46-91db-151f6cc751ef",
             "label": "No",
             "isExecuted": false,
             "group": null,
-            "uuid": "a533e0ac-f340-4fb7-9bf5-54b6b95b11dc"
+            "uuid": "649caaa9-3c07-4687-8022-e44e4ec1506e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Loggedin User Details -> Get Current User Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/2c4669a5-feca-4025-98f9-190c4ac2020c",
+            "sourceStep": "\/api\/3\/workflow_steps\/283d973a-f3b8-4b62-aab6-ef2d7e669b70",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9b4eb942-d579-4bef-b4bf-2557ea0aafcd"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Merge Pull Request.json
+++ b/playbooks/02 - Use Case - CICD/Merge Pull Request.json
@@ -81,7 +81,7 @@
                 "workflowReference": "\/api\/3\/workflows\/2bf34362-0466-4590-9ce5-845ce08860bc"
             },
             "status": null,
-            "top": "570",
+            "top": "620",
             "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -100,7 +100,7 @@
                 "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
             },
             "status": null,
-            "top": "300",
+            "top": "260",
             "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -112,12 +112,11 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{globalVars.cicd_config}}",
                 "current_user": "{{vars.currentUser | fromIRI}}",
-                "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}"
+                "source_control_type": "{{vars.cicd_config.source_control_url}}"
             },
             "status": null,
-            "top": "435",
+            "top": "500",
             "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -167,8 +166,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
-            "left": "835",
+            "top": "980",
+            "left": "840",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "1511cd33-7e15-4a27-8fd1-7993b4988eee"
@@ -204,11 +203,64 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "165",
+            "top": "140",
             "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "f2c59af5-9ff6-41c7-93ad-05dbf5113be7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "380",
+            "left": "660",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "dc9bd95d-db05-4462-be05-7380b259ca3b"
         },
         {
             "@type": "WorkflowStep",
@@ -267,7 +319,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetPullRequest\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1060",
+            "top": "1080",
             "left": "1020",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -317,7 +369,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "740",
             "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -605,8 +657,8 @@
                 "fsr_logged_in_user": "{{vars.currentUser | fromIRI}}"
             },
             "status": null,
-            "top": "840",
-            "left": "835",
+            "top": "860",
+            "left": "840",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "e2746475-8dcc-4bac-9fd1-dd0c7935801c"
@@ -685,7 +737,7 @@
             "name": "Update Last Commit ID",
             "description": null,
             "arguments": {
-                "when": "{{vars.steps.Get_Apply_Latest_Content_Record | lenght > 0}}",
+                "when": "{{vars.steps.Get_Apply_Latest_Content_Record | length > 0}}",
                 "resource": {
                     "lastCommitID": "{{vars.steps.Merge_Pull_Request.data.sha}}"
                 },
@@ -768,13 +820,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/c49e159c-0791-45a9-8492-dd57bc2db820",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/dc9bd95d-db05-4462-be05-7380b259ca3b",
             "sourceStep": "\/api\/3\/workflow_steps\/09582d16-0a7f-4aa8-aec4-72a9795141bd",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "35ce3b45-4f69-4969-89da-3148b98fbefc"
+            "uuid": "a91b97af-b2da-411a-a9d4-14a1b8bb0067"
         },
         {
             "@type": "WorkflowRoute",
@@ -845,6 +897,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "2b0926c7-a807-4bd0-ac7a-9541ecece5e7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/c49e159c-0791-45a9-8492-dd57bc2db820",
+            "sourceStep": "\/api\/3\/workflow_steps\/dc9bd95d-db05-4462-be05-7380b259ca3b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b9f9705e-b50d-4796-8895-150ce282c0eb"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
@@ -167,7 +167,7 @@
                 "base_branch_name": "{{vars.cicd_config.baseBranch}}"
             },
             "status": null,
-            "top": "940",
+            "top": "920",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -254,40 +254,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2180",
+            "top": "1980",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "f183e6b1-7bc4-4fa1-bbe5-c78d383d64b0"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Delete Pending Manual Inputs",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.steps.Get_Pending_Manual_Inputs.data['hydra:member'] | length > 0}}",
-                "params": {
-                    "iri": "\/api\/wf\/api\/manual-wf-input\/{{vars.item.id}}\/?format=json",
-                    "body": "",
-                    "method": "DELETE"
-                },
-                "version": "3.6.0",
-                "for_each": {
-                    "item": "{{vars.steps.Get_Pending_Manual_Inputs.data['hydra:member']}}",
-                    "parallel": false,
-                    "condition": ""
-                },
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1940",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "c99e76f8-69cb-4676-a6b9-fd7ddc2c9b65"
         },
         {
             "@type": "WorkflowStep",
@@ -312,11 +283,64 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1360",
+            "top": "1380",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "b0caaefc-675c-41d8-b924-7c18f923dc3c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "480",
+            "left": "820",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "3712b292-857c-4cff-99b6-89417fe47ffe"
         },
         {
             "@type": "WorkflowStep",
@@ -334,60 +358,11 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetCommit\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "1240",
+            "top": "1260",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "3bbe4b2e-eb2a-43b5-9659-5630c4e95d67"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Pending Manual Inputs",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/manual-wf-input\/list_wfinput\/?format=json&limit=10&offset=0&ordering=-id&record=%2Fapi%2F3%2Fchange_management%2F4be084b9-c5fe-4d42-943f-6bb2161d7157&unauthenticated_input=false",
-                    "body": "{\"assigned_to\":\"all\",\"is_approval\":false}",
-                    "method": "POST"
-                },
-                "version": "3.6.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1820",
-            "left": "120",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "06347ec2-e766-4463-a762-86b201c33a51"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?limit=50&name=cicd_config",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "ignore_errors": true,
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "cicd_config": "{{vars.result.data['hydra:member'][0].value | toDict }}"
-                }
-            },
-            "status": null,
-            "top": "480",
-            "left": "820",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "97bbbdf3-3802-4078-aeaa-229c9e3c75ab"
         },
         {
             "@type": "WorkflowStep",
@@ -398,7 +373,7 @@
                     {
                         "option": "Failed",
                         "step_iri": "\/api\/3\/workflow_steps\/43dbcd99-cb8e-47a8-84b0-7373c64230b8",
-                        "condition": "{{ vars.steps.Get_Source_Control_Details.status==\"failed\" or vars.steps.Get_Source_Control_Details.data['hydra:member'] | length == 0 }}",
+                        "condition": "{{ vars.cicd_config | length == 0 }}",
                         "step_name": "Source Control is not Configured"
                     },
                     {
@@ -435,7 +410,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1600",
+            "top": "1620",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -531,7 +506,7 @@
                 },
                 "isRecordLinked": true,
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Dev Settings\" %}{{vars.cicd_config.developmentSettings.split('\/')[-1]}}{% else %}{{vars.cicd_config.content.split('\/')[-1]}}{% endif %}"
+                    "repo_name": "{% if vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Dev Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 },
                 "response_mapping": {
                     "options": [
@@ -562,7 +537,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "940",
+            "top": "920",
             "left": "840",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -619,7 +594,7 @@
                 },
                 "isRecordLinked": true,
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Prod Settings\" %}{{vars.cicd_config.productionSettings.split('\/')[-1]}}{% else %}{{vars.cicd_config.content.split('\/')[-1]}}{% endif %}"
+                    "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Prod Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 },
                 "response_mapping": {
                     "options": [
@@ -650,8 +625,8 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "840",
-            "left": "475",
+            "top": "820",
+            "left": "480",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "e9297606-11c0-4951-9844-a07b16ef20a1"
@@ -811,9 +786,9 @@
                     "batch_size": 100
                 },
                 "resource": {
-                    "commitStatus": "<h5 style=\"color: #28a745;\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
+                    "commitStatus": "<h5 style=\"color: #28a745;\" class=\"margin-top-negative-1\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
                     "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}",
-                    "lastBuildDeployedOn": "{%if vars.repo_name == vars.cicd_config.content.split('\/')[-1] %}{{arrow.utcnow().int_timestamp}}{%else%}{{vars.input.records[0].lastBuildDeployedOn}}{%endif%}"
+                    "lastBuildDeployedOn": "{%if vars.repo_name == vars.cicd_config.contentRepoName %}{{arrow.utcnow().int_timestamp}}{%else%}{{vars.input.records[0].lastBuildDeployedOn}}{%endif%}"
                 },
                 "_showJson": false,
                 "operation": "Append",
@@ -826,7 +801,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2060",
+            "top": "1860",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -851,7 +826,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1480",
+            "top": "1500",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -939,7 +914,7 @@
                 }
             },
             "status": null,
-            "top": "1700",
+            "top": "1740",
             "left": "120",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
@@ -1039,16 +1014,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Delete Pending Manual Inputs -> Update Deployed Date",
-            "targetStep": "\/api\/3\/workflow_steps\/e343e5e7-c917-4e1a-bd82-53a3d2859c50",
-            "sourceStep": "\/api\/3\/workflow_steps\/c99e76f8-69cb-4676-a6b9-fd7ddc2c9b65",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "2d11afaa-f6a9-487b-a2ba-b9c0b22225e2"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Dummy Step1 -> Update Status to Pending",
             "targetStep": "\/api\/3\/workflow_steps\/9ddd19a2-5a0f-4186-a7d5-81f0462795d5",
             "sourceStep": "\/api\/3\/workflow_steps\/697bee6f-0ae5-4909-b131-13ff078007f5",
@@ -1069,6 +1034,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Has Source Control Configure",
+            "targetStep": "\/api\/3\/workflow_steps\/7196870f-c012-4ec4-a913-0f7ed5db3a50",
+            "sourceStep": "\/api\/3\/workflow_steps\/3712b292-857c-4cff-99b6-89417fe47ffe",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "03045334-40a5-4b0f-ba89-4fa6bfc0dac9"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Latest Commit -> Find Apply Latest Changes Record",
             "targetStep": "\/api\/3\/workflow_steps\/b0caaefc-675c-41d8-b924-7c18f923dc3c",
             "sourceStep": "\/api\/3\/workflow_steps\/3bbe4b2e-eb2a-43b5-9659-5630c4e95d67",
@@ -1076,26 +1051,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "a48fb4a3-e33e-495c-bc32-1ec104a9241f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Pending Manual Inputs -> Delete Pending Manual Inputs",
-            "targetStep": "\/api\/3\/workflow_steps\/c99e76f8-69cb-4676-a6b9-fd7ddc2c9b65",
-            "sourceStep": "\/api\/3\/workflow_steps\/06347ec2-e766-4463-a762-86b201c33a51",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "9feea06a-0745-4ed9-9761-5958fd6d9b7f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Has Source Control Configure",
-            "targetStep": "\/api\/3\/workflow_steps\/7196870f-c012-4ec4-a913-0f7ed5db3a50",
-            "sourceStep": "\/api\/3\/workflow_steps\/97bbbdf3-3802-4078-aeaa-229c9e3c75ab",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "9d0bc9fe-8d8d-4ca8-ad6a-78406d67f25e"
         },
         {
             "@type": "WorkflowRoute",
@@ -1239,23 +1194,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Status as In Progress -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/97bbbdf3-3802-4078-aeaa-229c9e3c75ab",
+            "name": "Update Status as In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/3712b292-857c-4cff-99b6-89417fe47ffe",
             "sourceStep": "\/api\/3\/workflow_steps\/3fed066c-a883-49a8-81bc-8be588136f89",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e260e4bc-2451-4c6b-979f-d97b59040d3c"
+            "uuid": "832eb654-57b3-4dfb-95bd-6e4574cf7b04"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Wait for Publish -> Get Pending Manual Inputs",
-            "targetStep": "\/api\/3\/workflow_steps\/06347ec2-e766-4463-a762-86b201c33a51",
+            "name": "Wait for Publish -> Update Deployed Date",
+            "targetStep": "\/api\/3\/workflow_steps\/e343e5e7-c917-4e1a-bd82-53a3d2859c50",
             "sourceStep": "\/api\/3\/workflow_steps\/2f0328bd-2b74-427e-b2e8-099ab6f4edbf",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "b98e49f3-475e-4ca7-9d42-4e3af4b9e667"
+            "uuid": "7442f705-5510-494a-80e3-25cf41e32524"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Push Change to Source Control.json
@@ -28,8 +28,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "825",
+            "top": "1245",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "10527b19-c15b-44c7-9e60-25d16ab941a3"
@@ -86,7 +86,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -115,8 +115,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "475",
+            "top": "1515",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "eec3b0cf-92b8-4e65-9a14-9ba7dbbdaa2f"
@@ -130,9 +130,7 @@
                     "playbook_name": "Push Change to Source Control"
                 },
                 "apply_async": false,
-                "step_variables": {
-                    "cicd_config": "{{globalVars.cicd_config | toDict}}"
-                },
+                "step_variables": [],
                 "pass_parent_env": false,
                 "pass_input_record": true,
                 "workflowReference": "\/api\/3\/workflows\/2bf34362-0466-4590-9ce5-845ce08860bc"
@@ -173,14 +171,13 @@
                 "new_branch": "CR-{{(vars.input.records[0].cRNo.split(\"target='_blank'>\")[-1]).split(\"<\/a>\")[0]}}",
                 "repo_owner": "{{vars.input.records[0].assigneeUsername}}",
                 "base_branch": "{{vars.input.records[0].baseBranch}}",
-                "cicd_config": "{{globalVars.cicd_config | toDict}}",
                 "export_file_name": "FortiSOAR Export-{{arrow.utcnow().int_timestamp}}",
                 "current_timestamp": "{{arrow.get((arrow.utcnow().int_timestamp  | int | abs)).format('YYYYMMDDHHmm')}}",
                 "source_control_type": "{{(globalVars.cicd_env| toDict).source_control.baseURL}}",
                 "export_template_name": "{% if vars.cicd_config[\"contentRepoName\"] in vars.input.records[0].repo_url %}Source Control - Production Content{% elif vars.cicd_config[\"devSettingsRepoName\"] in vars.input.records[0].repo_url %}Source Control - Development Settings{% else %}Source Control - Production Settings{% endif %}"
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -222,6 +219,59 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "db6ef86c-df20-4e80-a1d6-27fd7eecaf42"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "445f1922-e6df-41a1-8c55-306587a78307"
         },
         {
             "@type": "WorkflowStep",
@@ -275,7 +325,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -303,7 +353,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -359,8 +409,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
-            "left": "475",
+            "top": "1650",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "08027c16-ab47-4837-91ea-af29a3e0314f"
@@ -389,8 +439,8 @@
                 "workflowReference": "\/api\/3\/workflows\/8413a393-367b-4501-9196-ffbb027f0a3b"
             },
             "status": null,
-            "top": "1245",
-            "left": "475",
+            "top": "1380",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "cf2f32bf-453f-42d0-b6f8-9434ee1a2493"
@@ -494,8 +544,8 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "1110",
-            "left": "475",
+            "top": "1245",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "1deb2f29-0fdb-4a3d-9113-eddd876e4aa4"
@@ -622,13 +672,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Playbook Active or Awaiting -> Is Playbook Active or Awaiting",
-            "targetStep": "\/api\/3\/workflow_steps\/8eed896f-1c57-4601-a4c1-f5e625c0f1f4",
+            "name": "Check Playbook Active or Awaiting -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/445f1922-e6df-41a1-8c55-306587a78307",
             "sourceStep": "\/api\/3\/workflow_steps\/defada44-a146-4cf8-9b05-f9112af6d2fc",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "91919f6f-74ac-454f-86b7-668371fc65f5"
+            "uuid": "533987e6-4989-4482-b84b-1c98da6c4477"
         },
         {
             "@type": "WorkflowRoute",
@@ -649,6 +699,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "49edbc35-7edb-4518-bdca-cb7209e0a86f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Is Playbook Active or Awaiting",
+            "targetStep": "\/api\/3\/workflow_steps\/8eed896f-1c57-4601-a4c1-f5e625c0f1f4",
+            "sourceStep": "\/api\/3\/workflow_steps\/445f1922-e6df-41a1-8c55-306587a78307",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "70218b8d-309b-4a23-a2fb-8c3f1b782211"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Push Initial Production Environment Content.json
+++ b/playbooks/02 - Use Case - CICD/Push Initial Production Environment Content.json
@@ -23,11 +23,11 @@
             "description": null,
             "arguments": {
                 "org_name": "{{vars.cicd_config.organizationName}}",
-                "repo_name": "{{vars.cicd_config.content.split('\/')[-1]}}",
+                "repo_name": "{{vars.cicd_config.contentRepoName}}",
                 "base_branch": "{{vars.cicd_config.baseBranch}}",
                 "export_file_name": "Source Control - Production Content",
                 "current_timestamp": "{{arrow.get((arrow.utcnow().int_timestamp  | int | abs)).format('YYYYMMDDHHmm')}}",
-                "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}",
+                "source_control_type": "{{vars.cicd_config.source_control_url}}",
                 "export_template_name": "Source Control - Production Content"
             },
             "status": null,
@@ -36,6 +36,51 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "b901b9f1-3b1c-4d58-9d15-64278a39d3ba"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "environment",
+                            "value": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
+                                "itemValue": "Production"
+                            },
+                            "operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{{vars.steps.Find_Source_Control_Settings[0].configurationParameters}}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "5f5c0764-0b2f-405c-954a-fe723b47a8b0"
         },
         {
             "@type": "WorkflowStep",
@@ -76,31 +121,6 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "0f474223-ce80-4f51-a50d-e5a1d3f2469a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?limit=50&name=cicd_config",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "cicd_config": "{{vars.result.data['hydra:member'][0].value | toDict }}"
-                }
-            },
-            "status": null,
-            "top": "165",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "e5ceedee-4195-4cf5-81fa-5a1bffb8a291"
         },
         {
             "@type": "WorkflowStep",
@@ -154,7 +174,7 @@
             "description": null,
             "arguments": {
                 "resource": {
-                    "lastCommitID": "{{vars.steps.Push_Content_to_Source_Control.data.commit}}"
+                    "lastCommitID": "{{vars.steps.Push_Content_to_Source_Control.data.commit_sha}}"
                 },
                 "operation": "Append",
                 "collection": "{{vars.steps.Get_Apply_Latest_Content_Record[0]['@id']}}",
@@ -206,13 +226,23 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Push Export Config",
+            "name": "Configuration -> Push Content to Source Control",
             "targetStep": "\/api\/3\/workflow_steps\/fcf56774-db2c-4f8b-9595-1715ebbeefe8",
             "sourceStep": "\/api\/3\/workflow_steps\/b901b9f1-3b1c-4d58-9d15-64278a39d3ba",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "185c1f3b-3104-4bfb-a792-03d44e712988"
+            "uuid": "1069a890-06fb-4f68-9a08-2bd5424ec89c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/b901b9f1-3b1c-4d58-9d15-64278a39d3ba",
+            "sourceStep": "\/api\/3\/workflow_steps\/5f5c0764-0b2f-405c-954a-fe723b47a8b0",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b6d2bf42-3dda-4d30-82cf-fed35ef455cc"
         },
         {
             "@type": "WorkflowRoute",
@@ -226,16 +256,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/b901b9f1-3b1c-4d58-9d15-64278a39d3ba",
-            "sourceStep": "\/api\/3\/workflow_steps\/e5ceedee-4195-4cf5-81fa-5a1bffb8a291",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "eaede2a9-131b-4da8-bb69-daff4b900a72"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Push Export Config -> Update Record",
             "targetStep": "\/api\/3\/workflow_steps\/30cc2aaf-5dcc-4681-bf6d-13ee6ba536d9",
             "sourceStep": "\/api\/3\/workflow_steps\/fcf56774-db2c-4f8b-9595-1715ebbeefe8",
@@ -246,13 +266,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/e5ceedee-4195-4cf5-81fa-5a1bffb8a291",
+            "name": "Start -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/5f5c0764-0b2f-405c-954a-fe723b47a8b0",
             "sourceStep": "\/api\/3\/workflow_steps\/6b26f5cb-2ab1-4bc7-a1b1-b5b6e1ac3d01",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "3eee7a22-d62b-48c7-8c28-79836f9173fc"
+            "uuid": "e16c2ba8-d3b8-4a88-8671-5fa3609ab41b"
         },
         {
             "@type": "WorkflowRoute",
@@ -268,7 +288,7 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "50d8f3e9-11e6-4331-892a-dbddaefbbd3b",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
+++ b/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
@@ -34,8 +34,8 @@
                 "workflowReference": "\/api\/3\/workflows\/fce53c7e-778d-48aa-afb7-8f67830570ab"
             },
             "status": null,
-            "top": "840",
-            "left": "120",
+            "top": "975",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8"
@@ -53,7 +53,7 @@
                 "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -65,10 +65,10 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{globalVars.cicd_config}}"
+                "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
             },
             "status": null,
-            "top": "165",
+            "top": "300",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -112,11 +112,62 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "cef8c18f-187f-4697-b472-37226b9c1980"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "815c0c2f-f6fa-46c0-a5ae-15dd8d140b5b"
         },
         {
             "@type": "WorkflowStep",
@@ -134,7 +185,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetCommit\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -162,7 +213,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -181,7 +232,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -242,6 +293,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/f6b0783b-a048-48d4-ba50-56f2db68674b",
+            "sourceStep": "\/api\/3\/workflow_steps\/815c0c2f-f6fa-46c0-a5ae-15dd8d140b5b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d819b89f-87d1-40d2-af1c-d41a7ea95477"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Latest Commit -> Is Commit id Drift",
             "targetStep": "\/api\/3\/workflow_steps\/2dc6565e-de0b-4331-9d55-12a106ca3793",
             "sourceStep": "\/api\/3\/workflow_steps\/826926d6-cdb7-4ee8-bdff-5fe1bbe57ad7",
@@ -272,19 +333,19 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/f6b0783b-a048-48d4-ba50-56f2db68674b",
+            "name": "Start -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/815c0c2f-f6fa-46c0-a5ae-15dd8d140b5b",
             "sourceStep": "\/api\/3\/workflow_steps\/668f019d-d72e-4249-8342-c6b671ae1cc6",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "07e22481-794c-4229-87f9-ea2b689f61b6"
+            "uuid": "1b3a7890-5072-4bc5-bc35-a5cbc08cca6e"
         }
     ],
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": false,
+    "isEditable": true,
     "uuid": "0d655fb4-fb06-45c7-8b92-3ecb61b1b369",
     "owners": [],
     "isPrivate": false,
@@ -324,14 +385,14 @@
                 },
                 "exit_if_running": false,
                 "createUser": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
-                "name": "CICD-Retrieve Source Control Sync Status",
+                "name": "Ingest_Source-Control-Sync-Status(CICD)",
                 "description": "CICD-Retrieve Source Control Sync Status",
                 "auth": {
                     "auth_method": "CS HMAC"
                 },
                 "referenceid": null,
                 "schedule_entry_name": "Ingest_Source-Control-Sync-Status(CICD)",
-                "schedule_id": "50b22463-a821-450b-ac4d-f1454636a16d",
+                "schedule_id": "b63ccd61-9970-4853-a4f6-1a50be3bbc12",
                 "expired": false,
                 "start_time": null,
                 "expires": null,

--- a/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
+++ b/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
@@ -167,7 +167,7 @@
                     "recordTags": "Overwrite"
                 },
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Development Settings\" %}{{vars.cicd_config.developmentSettings.split('\/')[-1]}}{% else %}{{vars.cicd_config.content.split('\/')[-1]}}{% endif %}"
+                    "repo_name": "{% if vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Dev Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 }
             },
             "status": null,
@@ -179,29 +179,56 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
+            "name": "Find Source Control Settings",
             "description": null,
             "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?limit=50&name=cicd_config",
-                    "body": "",
-                    "method": "GET"
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
                 },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "ignore_errors": true,
-                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
                 "step_variables": {
-                    "cicd_config": "{{vars.result.data['hydra:member'][0].value | toDict }}"
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
                 }
             },
             "status": null,
             "top": "570",
             "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
-            "uuid": "25571701-2721-4090-a18d-ea41c2f483b0"
+            "uuid": "b625b844-8d94-447f-b424-460143465e5f"
         },
         {
             "@type": "WorkflowStep",
@@ -212,7 +239,7 @@
                     {
                         "option": "Failed",
                         "step_iri": "\/api\/3\/workflow_steps\/476acb98-a2f4-4619-b004-3bf9345afcfa",
-                        "condition": "{{ vars.steps.Get_Source_Control_Details.status==\"failed\" or vars.steps.Get_Source_Control_Details.data['hydra:member'] | length == 0 }}",
+                        "condition": "{{ vars.cicd_config | length == 0 }}",
                         "step_name": "Source Control is not Configured"
                     },
                     {
@@ -237,6 +264,7 @@
             "description": null,
             "arguments": {
                 "name": "CICD Utils",
+                "config": "8ce6b138-aed4-4b75-b3d7-eab72c959e54",
                 "params": {
                     "filename": "{{vars.steps.Clone_Repository.data.path.split('\/')[-1]}}",
                     "file_path": "{{vars.steps.Clone_Repository.data.path}}"
@@ -252,8 +280,8 @@
                 },
                 "version": "1.1.0",
                 "connector": "cicd-utils",
-                "operation": "import_fortisoar_template",
-                "operationTitle": "Import FortiSOAR Template",
+                "operation": "review_import_fortisoar_template",
+                "operationTitle": "Review & Import FortiSOAR Template",
                 "pickFromTenant": false,
                 "step_variables": []
             },
@@ -313,7 +341,7 @@
                     "recordTags": "Overwrite"
                 },
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Production Settings\" %}{{vars.cicd_config.productionSettings.split('\/')[-1]}}{% else %}{{vars.cicd_config.content.split('\/')[-1]}}{% endif %}"
+                    "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Prod Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 }
             },
             "status": null,
@@ -513,13 +541,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Has Source Control Configure",
+            "name": "Find Source Control Settings -> Has Source Control Configure",
             "targetStep": "\/api\/3\/workflow_steps\/2bc25de7-1c98-4459-b340-f7a4e5a29e8f",
-            "sourceStep": "\/api\/3\/workflow_steps\/25571701-2721-4090-a18d-ea41c2f483b0",
+            "sourceStep": "\/api\/3\/workflow_steps\/b625b844-8d94-447f-b424-460143465e5f",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "43bf8f1c-36b0-4cc9-be54-4fca0090eb03"
+            "uuid": "0e55767e-d180-45d4-aba8-58fc8bda016e"
         },
         {
             "@type": "WorkflowRoute",
@@ -583,19 +611,19 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Status as In Progress -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/25571701-2721-4090-a18d-ea41c2f483b0",
+            "name": "Update Status as In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/b625b844-8d94-447f-b424-460143465e5f",
             "sourceStep": "\/api\/3\/workflow_steps\/e412db53-236b-424d-be9d-a4a1f1769295",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "6559b6d7-65e4-4473-a7ed-6e17ca2e7801"
+            "uuid": "28506e83-6155-4193-9870-2a1c217de81f"
         }
     ],
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "24963415-4057-4fd5-bbe5-bf7d6bfa059d",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Save FortiSOAR Settings.json
+++ b/playbooks/02 - Use Case - CICD/Save FortiSOAR Settings.json
@@ -128,11 +128,11 @@
             "description": null,
             "arguments": {
                 "org_name": "{{vars.cicd_config.organizationName}}",
-                "repo_name": "{% if vars.input.records[0].title == \"Save Production Settings\" %}{{vars.cicd_config.productionSettings.split('\/')[-1]}}{% else %}{{vars.cicd_config.developmentSettings.split('\/')[-1]}}{% endif %}",
+                "repo_name": "{% if vars.input.records[0].title == \"Save Production Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% else %}{{vars.cicd_config.devSettingsRepoName}}{% endif %}",
                 "base_branch": "{{vars.cicd_config.baseBranch}}",
                 "export_file_name": "{% if vars.input.records[0].title == \"Save Production Settings\" %}{{\"Source Control - Production Settings\"}}{% else %}{{\"Source Control - Development Settings\"}}{% endif %}",
                 "current_timestamp": "{{arrow.get((arrow.utcnow().int_timestamp  | int | abs)).format('YYYYMMDDHHmm')}}",
-                "source_control_type": "{{(globalVars.cicd_config | toDict)[\"source_control_web_url\"] }}",
+                "source_control_type": "{{vars.cicd_config.source_control_url}}",
                 "export_template_name": "{% if vars.input.records[0].title == \"Save Production Settings\" %}{{\"Source Control - Production Settings\"}}{% else %}{{\"Source Control - Development Settings\"}}{% endif %}"
             },
             "status": null,
@@ -144,29 +144,56 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
+            "name": "Find Source Control Settings",
             "description": null,
             "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?limit=50&name=cicd_config",
-                    "body": "",
-                    "method": "GET"
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
                 },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "ignore_errors": true,
-                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
                 "step_variables": {
-                    "cicd_config": "{{vars.result.data['hydra:member'][0].value | toDict }}"
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
                 }
             },
             "status": null,
             "top": "570",
             "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
-            "uuid": "12bd3091-2ff7-45d5-930e-be2d9fff5a37"
+            "uuid": "8e14101b-1f98-45b5-a4c0-1cbc2ea5e09e"
         },
         {
             "@type": "WorkflowStep",
@@ -177,7 +204,7 @@
                     {
                         "option": "Failed",
                         "step_iri": "\/api\/3\/workflow_steps\/5b88ad2b-3d04-45bc-a8e0-e1a3a40cdc4d",
-                        "condition": "{{ vars.steps.Get_Source_Control_Details.status==\"failed\" or vars.steps.Get_Source_Control_Details.data['hydra:member'] | length == 0 }}",
+                        "condition": "{{ vars.cicd_config | length == 0 }}",
                         "step_name": "Source Control is not Configured"
                     },
                     {
@@ -582,13 +609,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Has Source Control Configure",
+            "name": "Find Source Control Settings -> Has Source Control Configure",
             "targetStep": "\/api\/3\/workflow_steps\/eaf399ef-7920-41e5-bb94-cc37a2870203",
-            "sourceStep": "\/api\/3\/workflow_steps\/12bd3091-2ff7-45d5-930e-be2d9fff5a37",
+            "sourceStep": "\/api\/3\/workflow_steps\/8e14101b-1f98-45b5-a4c0-1cbc2ea5e09e",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "9e47c6ba-9464-4ae3-b59e-1d037dddce5e"
+            "uuid": "b8ff1748-c0f5-4902-8928-be6f830b61af"
         },
         {
             "@type": "WorkflowRoute",
@@ -662,13 +689,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Status In Progress -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/12bd3091-2ff7-45d5-930e-be2d9fff5a37",
+            "name": "Update Status In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/8e14101b-1f98-45b5-a4c0-1cbc2ea5e09e",
             "sourceStep": "\/api\/3\/workflow_steps\/dfc0dbd2-46d2-4e21-8d06-4ab4dcf466fb",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "3198c2fb-5679-4f39-8fc8-33ca408064d3"
+            "uuid": "03205402-8ae0-4803-8d00-89460df0f943"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Set Source Control Username.json
+++ b/playbooks/02 - Use Case - CICD/Set Source Control Username.json
@@ -158,8 +158,8 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "560",
-            "left": "120",
+            "top": "570",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "64895882-1da3-4c57-8046-28b50aadb367"
@@ -501,29 +501,56 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
+            "name": "Find Source Control Settings",
             "description": null,
             "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?limit=50&name=cicd_config",
-                    "body": "",
-                    "method": "GET"
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
                 },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "ignore_errors": true,
-                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
                 "step_variables": {
-                    "cicd_config": "{{vars.result.data['hydra:member'][0].value | toDict }}"
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
                 }
             },
             "status": null,
             "top": "300",
             "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
-            "uuid": "c596c038-9b0b-4fe8-9ddb-6c5f5507701d"
+            "uuid": "6df3ef65-869e-46a5-9e57-dd0f1149c123"
         },
         {
             "@type": "WorkflowStep",
@@ -729,12 +756,12 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
                     "thread": false,
-                    "content": "<p class=\"mp-tile-description muted-80\"><strong>Mapped Following FortiSOAR User<\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li class=\"mp-tile-description muted-80\"><em>FortiSOAR User: <\/em><a href=\"{{vars.request.baseUri}}\/security\/people\" target=\"_blank\" rel=\"noopener\">{{vars.fsr_username}}<\/a><\/li>\n<li class=\"mp-tile-description muted-80\"><em>Source Control User:<\/em> {{vars.source_control_username}}<\/li>\n<\/ul>",
+                    "content": "<p>{{vars.steps.Find_Previous_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\"><strong>Mapped Following FortiSOAR User<\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li class=\"mp-tile-description muted-80\"><em>FortiSOAR User: <\/em>{{vars.fsr_username}}<\/li>\n<li class=\"mp-tile-description muted-80\"><em>Source Control User:<\/em> {{vars.source_control_username}}<\/li>\n<\/ul>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/05bcfc1c-3b6a-4fbb-a4de-a5b5c662366d"
                 },
                 "resource": {
-                    "results": "<p>{{vars.steps.Find_Previous_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\"><strong>Mapped Following FortiSOAR User<\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li class=\"mp-tile-description muted-80\"><em>FortiSOAR User: <\/em><a rel=\"noopener\" target=\"_blank\" href=\"{{vars.request.baseUri}}\/security\/people\">{{vars.fsr_username}}<\/a><\/li>\n<li class=\"mp-tile-description muted-80\"><em>Source Control User:<\/em> {{vars.source_control_username}}<\/li>\n<\/ul>"
+                    "results": "<p>{{vars.steps.Find_Previous_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\"><strong>Mapped Following FortiSOAR User<\/strong><\/p>\n<ul class=\"font-size-13 muted-80\">\n<li class=\"mp-tile-description muted-80\"><em>FortiSOAR User: <\/em>{{vars.fsr_username}}<\/li>\n<li class=\"mp-tile-description muted-80\"><em>Source Control User:<\/em> {{vars.source_control_username}}<\/li>\n<\/ul>"
                 },
                 "operation": "Append",
                 "collection": "{{vars.input.records[0]['@id']}}",
@@ -762,12 +789,12 @@
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
                     "thread": false,
-                    "content": "<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_content_role'] or vars.steps.Add_Production_Collaborator.input['prod_content_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Content Repository\" to <a rel=\"noopener\" target=\"_blank\" href=\"{{vars.request.baseUri}}\/security\/people\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_settings_role'] or vars.steps.Add_Production_Collaborator.input['prod_settings_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Settings Repository\" to <a rel=\"noopener\" target=\"_blank\" href=\"{{vars.request.baseUri}}\/security\/people\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['dev_settings_role'] or vars.steps.Add_Production_Collaborator.input['dev_settings_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Development Settings Repository\" to <a rel=\"noopener\" target=\"_blank\" href=\"{{vars.request.baseUri}}\/security\/people\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>",
+                    "content": "<p>{{vars.steps.Find_Previous_Updated_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_content_role'] or vars.steps.Add_Production_Collaborator.input['prod_content_role'] %}<\/p>\n<ul>\n<li class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Content Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/li>\n<\/ul>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_settings_role'] or vars.steps.Add_Production_Collaborator.input['prod_settings_role'] %}<\/p>\n<ul>\n<li class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Settings Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/li>\n<\/ul>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['dev_settings_role'] or vars.steps.Add_Production_Collaborator.input['dev_settings_role'] %}<\/p>\n<ul>\n<li class=\"mp-tile-description muted-80\">Assigned write permission on \"Development Settings Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/li>\n<\/ul>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/05bcfc1c-3b6a-4fbb-a4de-a5b5c662366d"
                 },
                 "resource": {
-                    "results": "<p>{{vars.steps.Find_Previous_Updated_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_content_role'] or vars.steps.Add_Production_Collaborator.input['prod_content_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Content Repository\" to <a href=\"{{vars.request.baseUri}}\/security\/people\" target=\"_blank\" rel=\"noopener\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_settings_role'] or vars.steps.Add_Production_Collaborator.input['prod_settings_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Production Settings Repository\" to <a href=\"{{vars.request.baseUri}}\/security\/people\" target=\"_blank\" rel=\"noopener\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['dev_settings_role'] or vars.steps.Add_Production_Collaborator.input['dev_settings_role'] %}<\/p>\n<p class=\"mp-tile-description muted-80\">Assigned write permission on \"Development Settings Repository\" to <a href=\"{{vars.request.baseUri}}\/security\/people\" target=\"_blank\" rel=\"noopener\">{{vars.fsr_username}}<\/a> FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>"
+                    "results": "<p>{{vars.steps.Find_Previous_Updated_Result[0].results}}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_content_role'] or vars.steps.Add_Production_Collaborator.input['prod_content_role'] %}<\/p>\n<p>- Assigned write permission on \"Production Content Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['prod_settings_role'] or vars.steps.Add_Production_Collaborator.input['prod_settings_role'] %}<\/p>\n<p>- Assigned write permission on \"Production Settings Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>\n<p class=\"mp-tile-description muted-80\">{% if vars.steps.Add_Development_Collaborator.input['dev_settings_role'] or vars.steps.Add_Production_Collaborator.input['dev_settings_role'] %}<\/p>\n<p>- Assigned write permission on \"Development Settings Repository\" to {{vars.fsr_username}} FortiSOAR user.<\/p>\n<p class=\"mp-tile-description muted-80\">{% endif %}<\/p>"
                 },
                 "operation": "Append",
                 "collection": "{{vars.input.records[0]['@id']}}",
@@ -945,13 +972,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Check Record Type",
+            "name": "Find Source Control Settings -> Check Record Type",
             "targetStep": "\/api\/3\/workflow_steps\/d17c4c86-f708-4dd1-b2b2-a42ea0f5be2f",
-            "sourceStep": "\/api\/3\/workflow_steps\/c596c038-9b0b-4fe8-9ddb-6c5f5507701d",
+            "sourceStep": "\/api\/3\/workflow_steps\/6df3ef65-869e-46a5-9e57-dd0f1149c123",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "b77258b6-80e5-4ae8-95b6-cf54537b5015"
+            "uuid": "addc5c9b-96f9-4c24-a27b-604e11302562"
         },
         {
             "@type": "WorkflowRoute",
@@ -985,13 +1012,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Set Status to In Progress -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/c596c038-9b0b-4fe8-9ddb-6c5f5507701d",
+            "name": "Set Status to In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/6df3ef65-869e-46a5-9e57-dd0f1149c123",
             "sourceStep": "\/api\/3\/workflow_steps\/4f4f48ea-abac-4fa2-973f-fcc404229264",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "a5067f0c-ae60-4913-a98a-be2b8828257c"
+            "uuid": "19f2d1b1-c874-46f4-b786-963ee32836b8"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
@@ -34,8 +34,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
-            "left": "300",
+            "top": "1515",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "7654b64e-acba-4cd9-a17f-5d473404c784"
@@ -47,11 +47,11 @@
             "arguments": {
                 "cicd_config": "{% set env = [] %}{% for item in vars.request.selectedEnv.picklist %}{% set _ = env.append({\"itemValue\": item.itemValue, \"@id\": item[\"@id\"]}) %}{% endfor %}{\"env_config\": {{env}}, \"source_control\": {{vars.request.sourceControl}}}",
                 "setup_record_list": "[\"Setup the Source Control for Production Environment\", \"Setup the Development Environment\"]",
-                "source_control_operations": "[\"{{vars.request.sourceControl.label}}-CreateRepository\",\n\"{{vars.request.sourceControl.label}}-UpdateRemoteRepository\",\n\"{{vars.request.sourceControl.label}}-UpdateIssue\",\n\"{{vars.request.sourceControl.label}}-PushChanges\",\n\"{{vars.request.sourceControl.label}}-MergePullRequest\",\n\"{{vars.request.sourceControl.label}}-ListRepositoryIssue\",\n\"{{vars.request.sourceControl.label}}-ListRepositoryCollaborator\",\n\"{{vars.request.sourceControl.label}}-ListPullRequest\",\n\"{{vars.request.sourceControl.label}}-ListPullRequestReviews\",\n\"{{vars.request.sourceControl.label}}-FetchRelease\",\n\"{{vars.request.sourceControl.label}}-DeleteBranch\",\n\"{{vars.request.sourceControl.label}}-CreateUpdateFileContent\",\n\"{{vars.request.sourceControl.label}}-CreateRelease\",\n\"{{vars.request.sourceControl.label}}-CreatePullRequest\",\n\"{{vars.request.sourceControl.label}}-CreateIssue\",\n\"{{vars.request.sourceControl.label}}-CreateIssueComment\",\n\"{{vars.request.sourceControl.label}}-CreateBranch\",\n\"{{vars.request.sourceControl.label}}-CloneRepository\",\n\"{{vars.request.sourceControl.label}}-PullRequestAddReviewers\",\n\"{{vars.request.sourceControl.label}}-AddRepositoryCollaborator\",\n\"{{vars.request.sourceControl.label}}-AddPullRequestReview\", \"{{vars.request.sourceControl.label}}-GetServerURL\", \"{{vars.request.sourceControl.label}}-GetRepository\", \"{{vars.request.sourceControl.label}}-GetPullRequest\", \"{{vars.request.sourceControl.label}}-GetCommit\", \"{{vars.request.sourceControl.label}}-GetCommitComparison\" ]"
+                "source_control_operations": "{% set filtered = [] %}{% for item in ((vars.steps.Get_Source_Control_Playbooks.data['hydra:member'] | json_query(\"[?isActive==`true`].recordTags\")) | flatten(levels=1)) %}{% if '-' in item %}{% do filtered.append(item) %}{% endif %}{% endfor %}{{filtered}}"
             },
             "status": null,
-            "top": "165",
-            "left": "300",
+            "top": "435",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "72d4a7bd-82d9-45ce-8092-de138c20189b"
@@ -72,65 +72,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "300",
+            "top": "1245",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "813442f4-8ab0-4a86-9af4-515fb8dc8985"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create CICD FSR Environment",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "key": "CICD FortiSOAR Environment",
-                    "value": "{{(vars.cicd_config.env_config | json_query(\"[].itemValue\")) | join(\",\")}}",
-                    "__replace": "true"
-                },
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/upsert\/keys",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1110",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "cdec3fcb-a5f8-48e3-9e4f-20c7db7fc3ca"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Fetch CICD FSR Environment",
-            "description": null,
-            "arguments": {
-                "query": {
-                    "sort": [],
-                    "limit": 30,
-                    "logic": "AND",
-                    "filters": [
-                        {
-                            "type": "primitive",
-                            "field": "key",
-                            "value": "CICD FortiSOAR Environment",
-                            "operator": "eq",
-                            "_operator": "eq"
-                        }
-                    ]
-                },
-                "module": "keys?$limit=30",
-                "step_variables": []
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
-            "group": null,
-            "uuid": "990d0bbb-f29c-40cf-89d4-2c51dfb5c771"
         },
         {
             "@type": "WorkflowStep",
@@ -155,11 +101,57 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
-            "left": "300",
+            "top": "570",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "0aded246-f9d5-48f2-829c-37952fe60070"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Playbook Collection",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/3\/workflow_collections?$limit=2147483647&$orderby=name&$relationships=true&__selectFields=fsr_primary,workflowCount&name=Sample - {{vars.request.sourceControl.label}} - {{vars.request.sourceControl.version}}",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.6.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "fc39f306-f324-47bc-a307-3d0bb2a2bbee"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Playbooks",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/3\/workflows?$limit=2147483647&$orderby=-modifyDate&collection={{vars.steps.Get_Source_Control_Playbook_Collection.data['hydra:member'][0].uuid}}",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.6.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "d5836224-b1bc-485b-b5d8-4f251df39d05"
         },
         {
             "@type": "WorkflowStep",
@@ -178,8 +170,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
-            "left": "300",
+            "top": "1380",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "71c4410e-c4d8-47b2-8387-775da6d096bc"
@@ -193,7 +185,7 @@
                     "query": "{\n    \"sort\": [\n        {\n            \"field\": \"createDate\",\n            \"direction\": \"DESC\",\n            \"_fieldName\": \"createDate\"\n        }\n    ],\n    \"limit\": 90,\n    \"logic\": \"AND\",\n    \"filters\": [\n        {\n            \"field\": \"recordTags\",\n            \"value\": [\"{{vars.item}}\"],\n            \"display\": \"\",\n            \"operator\": \"in\",\n            \"type\": \"array\",\n            \"OPERATOR_KEY\": \"$\"\n        },\n        {\n            \"field\": \"isActive\",\n            \"value\": true,\n            \"operator\": \"eq\"\n        }\n    ],\n    \"__selectFields\": [\n        \"id\", \"name\", \"recordTags\"\n    ]\n}",
                     "resource": "workflows"
                 },
-                "version": "3.2.6",
+                "version": "3.6.0",
                 "for_each": {
                     "item": "{{vars.source_control_operations}}",
                     "parallel": false,
@@ -203,44 +195,15 @@
                 "operation": "query_cyops_resource",
                 "operationTitle": "FSR: Find Record",
                 "step_variables": {
-                    "cicd_config": "{%set temp = {}%}{%set result = {}%}{% for i in vars.steps.Get_Source_Control_Workflows %}{% set result = {}%}{% for tag in i[\"data\"][0][\"recordTags\"] %}{% if '-' in tag %}{% set m = result.update({\"tag\": tag.split(\"-\")[-1]})%}{% endif %}\n{% endfor %}{% set a = temp.update({result[\"tag\"]: {\"name\": i[\"data\"][0][\"name\"],\"@id\": i[\"data\"][0][\"@id\"]}}) %}{% endfor %}{% set dummy = result.update({\"source_control_playbooks\": temp})%}{{result}}",
-                    "activeWorkflows": "{{vars.result.data|json_query(\"[][\\\"@id\\\"][]\")}}"
+                    "cicd_config": "{%set temp = {}%}{%set result = {}%}{% for i in vars.steps.Get_Source_Control_Workflows %}{% set result = {}%}{% for tag in i[\"data\"][0][\"recordTags\"] %}{% if '-' in tag %}{% set m = result.update({\"tag\": tag.split(\"-\")[-1]})%}{% endif %}\n{% endfor %}{% set a = temp.update({result[\"tag\"]: {\"name\": i[\"data\"][0][\"name\"],\"@id\": i[\"data\"][0][\"@id\"]}}) %}{% endfor %}{% set dummy = result.update({\"source_control_playbooks\": temp})%}{{result}}"
                 }
             },
             "status": null,
-            "top": "1245",
-            "left": "300",
+            "top": "1110",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "b688e2d8-9214-4196-9952-5f623d8637eb"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is CICD FSR Environment Record Exist",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Update CICD FSR Environment Record",
-                        "step_iri": "\/api\/3\/workflow_steps\/fc5e29ce-eb4e-4ce6-aca7-d0fe193df395",
-                        "condition": "{{ vars.steps.Fetch_CICD_FSR_Environment | length > 0 }}",
-                        "step_name": "Update CICD FSR Environment Record"
-                    },
-                    {
-                        "option": "Update CICD FSR Environment Record",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/cdec3fcb-a5f8-48e3-9e4f-20c7db7fc3ca",
-                        "step_name": "Create CICD FSR Environment"
-                    }
-                ],
-                "step_variables": []
-            },
-            "status": null,
-            "top": "975",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "7e0149cf-6ae4-4ccf-b5b8-633b0ec881f3"
         },
         {
             "@type": "WorkflowStep",
@@ -271,8 +234,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
-            "left": "300",
+            "top": "705",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "990eb8db-3c12-4144-bcda-9ba15717e849"
@@ -285,8 +248,8 @@
                 "setup_type": "{% if vars.cicd_config.env_config | length == 2 %}{{vars.steps.Set_Default_Environment_Type | json_query(\"[? environment.itemValue == 'Development']\")}}{% else %}{% for setup in vars.steps.Set_Default_Environment_Type %}{% if setup.environment.itemValue in vars.cicd_config.env_config[0].itemValue %}{{vars.steps.Set_Default_Environment_Type | json_query(\"[? environment.itemValue != '\"+vars.cicd_config.env_config[0].itemValue+\"']\")}}{% endif %}{% endfor %}{% endif %}"
             },
             "status": null,
-            "top": "705",
-            "left": "300",
+            "top": "840",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "559b2359-c7ca-40e3-8acc-06ff977dfad0"
@@ -304,34 +267,10 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e3243c1a-daf7-4bf1-901a-8cc380e797f2"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Update CICD FSR Environment Record",
-            "description": null,
-            "arguments": {
-                "resource": {
-                    "value": "{{(vars.cicd_config.env_config | json_query(\"[].itemValue\")) | join(\",\")}}"
-                },
-                "operation": "Append",
-                "collection": "{{vars.steps.Fetch_CICD_FSR_Environment[0]['@id']}}",
-                "__recommend": [],
-                "collectionType": "\/api\/3\/keys",
-                "fieldOperation": {
-                    "recordTags": "Append"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1110",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
-            "group": null,
-            "uuid": "fc5e29ce-eb4e-4ce6-aca7-d0fe193df395"
         },
         {
             "@type": "WorkflowStep",
@@ -349,8 +288,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "300",
+            "top": "975",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "b0ab255f-5db5-41f2-be7e-10f2160e850b"
@@ -359,13 +298,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Configuration -> Fetch CICD FSR Environment",
-            "targetStep": "\/api\/3\/workflow_steps\/990d0bbb-f29c-40cf-89d4-2c51dfb5c771",
+            "name": "Configuration -> Find Setup Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/0aded246-f9d5-48f2-829c-37952fe60070",
             "sourceStep": "\/api\/3\/workflow_steps\/72d4a7bd-82d9-45ce-8092-de138c20189b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "7bf0fb04-71c5-4d10-9f2f-c3e43b98dfea"
+            "uuid": "42bcbd96-73c2-4205-867d-3250d3dc063c"
         },
         {
             "@type": "WorkflowRoute",
@@ -376,26 +315,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "28d72f0e-2e06-4f6a-bc67-a1fac7b0bcf4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create CICD FSR Environment -> Get Source Control Workflows",
-            "targetStep": "\/api\/3\/workflow_steps\/b688e2d8-9214-4196-9952-5f623d8637eb",
-            "sourceStep": "\/api\/3\/workflow_steps\/cdec3fcb-a5f8-48e3-9e4f-20c7db7fc3ca",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "2b0fe6ea-e948-4e65-8026-f3ef01bfd60a"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Fetch CICD FSR Environment -> Find Setup Environment",
-            "targetStep": "\/api\/3\/workflow_steps\/0aded246-f9d5-48f2-829c-37952fe60070",
-            "sourceStep": "\/api\/3\/workflow_steps\/990d0bbb-f29c-40cf-89d4-2c51dfb5c771",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "be59c71c-3acc-4cbb-8025-4547b851f120"
         },
         {
             "@type": "WorkflowRoute",
@@ -419,6 +338,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Get Source Control Playbook Collection -> Get Source Control Playbooks",
+            "targetStep": "\/api\/3\/workflow_steps\/d5836224-b1bc-485b-b5d8-4f251df39d05",
+            "sourceStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d34fbcfd-828a-4a83-bb8d-e9834179b2a0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Playbooks -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/72d4a7bd-82d9-45ce-8092-de138c20189b",
+            "sourceStep": "\/api\/3\/workflow_steps\/d5836224-b1bc-485b-b5d8-4f251df39d05",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e346a6af-4d11-4d95-92dd-e7f355fb40cd"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Source Control Workflows -> Create CICD Env Global Variable",
             "targetStep": "\/api\/3\/workflow_steps\/813442f4-8ab0-4a86-9af4-515fb8dc8985",
             "sourceStep": "\/api\/3\/workflow_steps\/b688e2d8-9214-4196-9952-5f623d8637eb",
@@ -426,26 +365,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "afefa7ec-5173-4799-9e14-fc1abf97385c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is CICD FSR Environment Record Exist -> Create CICD FSR Environment",
-            "targetStep": "\/api\/3\/workflow_steps\/cdec3fcb-a5f8-48e3-9e4f-20c7db7fc3ca",
-            "sourceStep": "\/api\/3\/workflow_steps\/7e0149cf-6ae4-4ccf-b5b8-633b0ec881f3",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "9ee44c89-3c73-4e23-966d-c84128c0ee76"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is CICD FSR Environment Record Exist -> Update CICD FSR Environment Record",
-            "targetStep": "\/api\/3\/workflow_steps\/fc5e29ce-eb4e-4ce6-aca7-d0fe193df395",
-            "sourceStep": "\/api\/3\/workflow_steps\/7e0149cf-6ae4-4ccf-b5b8-633b0ec881f3",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "585d0d5f-34e8-4771-a37e-bf5f8648706d"
         },
         {
             "@type": "WorkflowRoute",
@@ -469,39 +388,29 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/72d4a7bd-82d9-45ce-8092-de138c20189b",
+            "name": "Start -> Get Source Control Playbook Collection",
+            "targetStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
             "sourceStep": "\/api\/3\/workflow_steps\/e3243c1a-daf7-4bf1-901a-8cc380e797f2",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "feb73928-b8b8-49fb-9304-1cd96ddbcdf0"
+            "uuid": "02911476-6c4c-4a4e-895b-e8fd33fcf8aa"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update CICD FSR Environment Record -> Get Source Control Workflows",
+            "name": "Update Setup Environment -> Get Source Control Workflows",
             "targetStep": "\/api\/3\/workflow_steps\/b688e2d8-9214-4196-9952-5f623d8637eb",
-            "sourceStep": "\/api\/3\/workflow_steps\/fc5e29ce-eb4e-4ce6-aca7-d0fe193df395",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "d76652da-b750-45dd-9924-e74a75a5f82d"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Update Setup Environment -> Is CICD FSR Environment Record Exist",
-            "targetStep": "\/api\/3\/workflow_steps\/7e0149cf-6ae4-4ccf-b5b8-633b0ec881f3",
             "sourceStep": "\/api\/3\/workflow_steps\/b0ab255f-5db5-41f2-be7e-10f2160e850b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "2106dfa4-7cb7-4960-ab18-99f22e701085"
+            "uuid": "b2dd0f48-69b2-4724-8c59-5dca15f14564"
         }
     ],
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": false,
+    "isEditable": true,
     "uuid": "936a5236-e7ca-4c44-b3cf-cce8937df365",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Setup Development Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup Development Environment.json
@@ -29,7 +29,7 @@
             },
             "status": null,
             "top": "705",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "ff9d7102-e5eb-422f-a0fd-f1fde6ce92a1"
@@ -50,8 +50,8 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CloneRepository\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "2190",
-            "left": "218",
+            "top": "2055",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "8d4b5b51-08ba-43a7-814c-66b65cfd69bf"
@@ -65,34 +65,10 @@
             },
             "status": null,
             "top": "165",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "8c92404f-c1d4-4491-9901-6d539f85a60d"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create Repository Global Variable",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "macro": "{{\"cicd_config\"}}",
-                    "value": "{{ ({\"organizationName\": vars.organization_name, \"content\": vars.content_repo_url, \"developmentSettings\": vars.dev_settings_url, \"baseBranch\": vars.base_branch,  \"contentRepoName\": vars.content_repo_url.split(\"\/\")[-1], \"devSettingsRepoName\": vars.dev_settings_url.split(\"\/\")[-1]}) | toJSON}}"
-                },
-                "version": "3.3.0",
-                "connector": "cyops_utilities",
-                "operation": "updatemacro",
-                "operationTitle": "FSR: Create\/Update Global Variables",
-                "step_variables": {
-                    "cicd_config": "{{vars.result.data.value | toDict}}"
-                }
-            },
-            "status": null,
-            "top": "1780",
-            "left": "540",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "747f53dd-ba2f-4e8f-85b9-79f1ee762909"
         },
         {
             "@type": "WorkflowStep",
@@ -114,7 +90,7 @@
             },
             "status": null,
             "top": "1520",
-            "left": "540",
+            "left": "440",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "99743434-451f-4875-80a0-97015a247b59"
@@ -146,11 +122,56 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2730",
-            "left": "218",
+            "top": "2595",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "762289c3-2ae5-445f-bd09-8262327e4d24"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "environment",
+                            "value": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
+                                "itemValue": "Development"
+                            },
+                            "operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_config": "{% if vars.steps.Find_Source_Control_Settings[0] | length > 0 %}{{vars.steps.Find_Source_Control_Settings[0].configurationParameters}}{% else %}\"\"{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "d6361533-2559-4343-bb71-7fce9c195643"
         },
         {
             "@type": "WorkflowStep",
@@ -161,7 +182,7 @@
             },
             "status": null,
             "top": "975",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "1125eddb-13a9-45aa-b9cb-f0cccbbe3c03"
@@ -273,35 +294,10 @@
             },
             "status": null,
             "top": "1380",
-            "left": "540",
+            "left": "440",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "908ec37d-cb1f-4c45-955a-11324893b0d3"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Source Control Details",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/wf\/api\/dynamic-variable\/?name=cicd_config",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "cicd_config": "{% if vars.result.data['hydra:member'] | length %}{{vars.result.data['hydra:member'][0].value | toDict }}{% else %}\"\"{% endif %}"
-                }
-            },
-            "status": null,
-            "top": "435",
-            "left": "218",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "c97f2a05-3f50-4af6-bed4-ffacf3bd83a3"
         },
         {
             "@type": "WorkflowStep",
@@ -319,21 +315,21 @@
             },
             "status": null,
             "top": "840",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "3e498601-2199-4e52-a2b6-ff42943f76da"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Has CICD Config Global Variable Exist",
+            "name": "Has CICD Config Params Exist",
             "description": null,
             "arguments": {
                 "conditions": [
                     {
                         "option": "Yes",
                         "step_iri": "\/api\/3\/workflow_steps\/6df36f21-d838-4e86-987b-c6c18d4b7281",
-                        "condition": "{{ vars.cicd_config | length > 0 }}",
+                        "condition": "{{ vars.cicd_config is not none and vars.cicd_config | length > 0 }}",
                         "step_name": "Repository Details"
                     },
                     {
@@ -347,7 +343,7 @@
             },
             "status": null,
             "top": "1245",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "41b959ae-15eb-4786-9849-2da4f0ea5a5a"
@@ -370,8 +366,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2325",
-            "left": "218",
+            "top": "2190",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
             "uuid": "2ed5ac1b-7bbe-4353-a2e3-dad9dd3de464"
@@ -389,7 +385,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "c743714d-a718-4aef-9e2e-f98d86501c21"
@@ -399,14 +395,14 @@
             "name": "Repository Details",
             "description": null,
             "arguments": {
-                "org_name": "{{vars.cicd_config.organizationName or vars.organization_name}}",
-                "base_branch": "{{vars.cicd_config.baseBranch}}",
-                "content_repo": "{{vars.cicd_config.content.split('\/')[-1] or vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
-                "dev_settings_repo": "{{vars.cicd_config.developmentSettings.split('\/')[-1] or vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}"
+                "org_name": "{{vars.cicd_config.organizationName or vars.steps.Get_Repositories_Details.input.orgName}}",
+                "base_branch": "{{vars.cicd_config.baseBranch or vars.steps.Get_Repositories_Details.input.baseBranchName}}",
+                "content_repo": "{{vars.cicd_config.contentRepoName or vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
+                "dev_settings_repo": "{{vars.cicd_config.devSettingsRepoName or vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}"
             },
             "status": null,
-            "top": "1920",
-            "left": "218",
+            "top": "1785",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "6df36f21-d838-4e86-987b-c6c18d4b7281"
@@ -435,28 +431,11 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2865",
-            "left": "218",
+            "top": "2730",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a20d0c91-0db4-4716-acb2-5ef1fb5f501a"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Source Control Parameters",
-            "description": null,
-            "arguments": {
-                "base_branch": "{{vars.steps.Get_Repositories_Details.input.baseBranchName}}",
-                "content_repo_url": "{{vars.cicd_env.source_control.baseURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
-                "dev_settings_url": "{{vars.cicd_env.source_control.baseURL}}\/{{vars.steps.Get_Repositories_Details.input.orgName}}\/{{vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}",
-                "organization_name": "{{vars.steps.Get_Repositories_Details.input.orgName}}"
-            },
-            "status": null,
-            "top": "1640",
-            "left": "540",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "f8146597-a026-47dd-8c57-2cec35cc752b"
         },
         {
             "@type": "WorkflowStep",
@@ -477,8 +456,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2595",
-            "left": "218",
+            "top": "2460",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "bd53e719-1993-4ebf-b7d4-439aa0d16ef5"
@@ -510,7 +489,7 @@
             },
             "status": null,
             "top": "300",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "34b7c5f5-4bae-4625-b626-cd8bed4060d8"
@@ -574,7 +553,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "ac61e885-f89b-4ca1-9484-ae4e32fd3b76"
@@ -596,7 +575,7 @@
             },
             "status": null,
             "top": "1110",
-            "left": "218",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "a9731156-d8f1-4bd6-8387-7d0118f834db"
@@ -628,11 +607,41 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2055",
-            "left": "218",
+            "top": "1920",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a15139eb-490e-4198-9c80-997d454e56c6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Source Control Settings Config",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "configurationParameters": {
+                        "baseBranch": "{{vars.steps.Get_Repositories_Details.input.baseBranchName}}",
+                        "contentRepoName": "{{vars.steps.Get_Repositories_Details.input.contentRepositoryName}}",
+                        "organizationName": "{{vars.steps.Get_Repositories_Details.input.orgName}}",
+                        "source_control_url": "{{vars.cicd_env.source_control.baseURL}}\/",
+                        "devSettingsRepoName": "{{vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}"
+                    }
+                },
+                "operation": "Append",
+                "collection": "{{vars.steps.Find_Source_Control_Settings[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1660",
+            "left": "440",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a30e093b-ac0a-4a95-9e17-2141c7fd8037"
         },
         {
             "@type": "WorkflowStep",
@@ -660,8 +669,8 @@
                 }
             },
             "status": null,
-            "top": "2460",
-            "left": "218",
+            "top": "2325",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
             "uuid": "892ed89d-53eb-42a3-8228-fa7f2d1b124a"
@@ -700,26 +709,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Repository Details -> Create Repository Global Variable",
-            "targetStep": "\/api\/3\/workflow_steps\/747f53dd-ba2f-4e8f-85b9-79f1ee762909",
-            "sourceStep": "\/api\/3\/workflow_steps\/f8146597-a026-47dd-8c57-2cec35cc752b",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "c4716770-1576-4b8c-87a7-12781ff010e4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Repository Global Variable -> Repository Details1",
-            "targetStep": "\/api\/3\/workflow_steps\/6df36f21-d838-4e86-987b-c6c18d4b7281",
-            "sourceStep": "\/api\/3\/workflow_steps\/747f53dd-ba2f-4e8f-85b9-79f1ee762909",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "2ee1a3b2-cd3d-4cec-abf1-f395621d25c8"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "d -> Wait for Publish",
             "targetStep": "\/api\/3\/workflow_steps\/892ed89d-53eb-42a3-8228-fa7f2d1b124a",
             "sourceStep": "\/api\/3\/workflow_steps\/2ed5ac1b-7bbe-4353-a2e3-dad9dd3de464",
@@ -730,13 +719,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Fetch Source Control Details -> Set Source Control Parameters",
-            "targetStep": "\/api\/3\/workflow_steps\/f8146597-a026-47dd-8c57-2cec35cc752b",
+            "name": "Fetch Source Control Details -> Update Source Control Settings Config",
+            "targetStep": "\/api\/3\/workflow_steps\/a30e093b-ac0a-4a95-9e17-2141c7fd8037",
             "sourceStep": "\/api\/3\/workflow_steps\/99743434-451f-4875-80a0-97015a247b59",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "fbf56e6c-8d8e-4f76-8190-e75bbfd2a272"
+            "uuid": "b31ab5b5-4d37-471c-a83b-247d4178aa41"
         },
         {
             "@type": "WorkflowRoute",
@@ -747,6 +736,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "d806a431-5bd3-4454-a9d0-37314c1d9bc3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Map Source Control Username",
+            "targetStep": "\/api\/3\/workflow_steps\/c743714d-a718-4aef-9e2e-f98d86501c21",
+            "sourceStep": "\/api\/3\/workflow_steps\/d6361533-2559-4343-bb71-7fce9c195643",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6b482017-da21-4832-a5f5-b596a842aff0"
         },
         {
             "@type": "WorkflowRoute",
@@ -767,16 +766,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "13e9e72e-12b2-4509-a93a-8a337dcf2b85"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Source Control Details -> Map Source Control Username",
-            "targetStep": "\/api\/3\/workflow_steps\/c743714d-a718-4aef-9e2e-f98d86501c21",
-            "sourceStep": "\/api\/3\/workflow_steps\/c97f2a05-3f50-4af6-bed4-ffacf3bd83a3",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "1cd577d9-1cfc-46fe-940e-732d0a7c5dd6"
         },
         {
             "@type": "WorkflowRoute",
@@ -830,13 +819,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Set Status In Progress -> Get Source Control Details",
-            "targetStep": "\/api\/3\/workflow_steps\/c97f2a05-3f50-4af6-bed4-ffacf3bd83a3",
+            "name": "Set Status In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/d6361533-2559-4343-bb71-7fce9c195643",
             "sourceStep": "\/api\/3\/workflow_steps\/34b7c5f5-4bae-4625-b626-cd8bed4060d8",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "5784b13c-75b1-4dbf-b3d0-0ad9de9af209"
+            "uuid": "fd3d6906-7e1f-4043-a8fd-18f1941e72f8"
         },
         {
             "@type": "WorkflowRoute",
@@ -867,6 +856,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "eb3e1e14-42a1-45dc-9eed-c727c4334319"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Source Control Settings Config -> Repository Details",
+            "targetStep": "\/api\/3\/workflow_steps\/6df36f21-d838-4e86-987b-c6c18d4b7281",
+            "sourceStep": "\/api\/3\/workflow_steps\/a30e093b-ac0a-4a95-9e17-2141c7fd8037",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7ba6ba35-176b-4c60-8c0f-10d3733df60a"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Update Source Control Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Update Source Control Configuration.json
@@ -1,0 +1,384 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Update Source Control Configuration",
+    "aliasName": null,
+    "tag": null,
+    "description": "Update source control settings including the base branch, repository names, organization, and source control URL.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/4c58fed3-9e16-451a-9528-0be2b71acda4",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/6c412126-9186-44a4-b8b9-ae1ea35de86b",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "updated_config": "{\n  \"baseBranch\" : \"{{vars.steps.Configuration_Parameters.input.baseBranch}}\",\n  \"contentRepoName\" : \"{{vars.steps.Configuration_Parameters.input.contentRepository}}\",\n  \"organizationName\" : \"{{vars.steps.Configuration_Parameters.input.organization}}\",\n  \"source_control_url\" : \"{{vars.steps.Configuration_Parameters.input.sourceControlURL}}\", \n  \"devSettingsRepoName\" : \"{{vars.steps.Configuration_Parameters.input.developmentSettingsRepository}}\",\n  \"prodSettingsRepoName\" : \"{{vars.steps.Configuration_Parameters.input.productionSettingsRepository}}\"\n}"
+            },
+            "status": null,
+            "top": "435",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "da1693d1-670c-4942-bd7f-b12d24599bfd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration Parameters",
+            "description": null,
+            "arguments": {
+                "type": "InputBased",
+                "input": {
+                    "schema": {
+                        "title": "Update Source Control Configuration",
+                        "description": "Update the source control settings below if required. \nThese values are used during CICD-related source control operations. Ensure all entries are accurate to prevent synchronization or deployment issues.",
+                        "inputVariables": [
+                            {
+                                "name": "sourceControlURL",
+                                "type": "string",
+                                "label": "Source Control URL",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": false,
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.source_control_url}}",
+                                "_previousName": "sourceControl",
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "organization",
+                                "type": "string",
+                                "label": "Organization",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": false,
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.organizationName}}",
+                                "_previousName": "organizationName",
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "baseBranch",
+                                "type": "string",
+                                "label": "Base Branch",
+                                "title": "Dynamic List",
+                                "usable": true,
+                                "options": "{{vars.input.records[0].configurationParameters}}",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": false,
+                                "mmdUpdate": true,
+                                "collection": false,
+                                "searchable": false,
+                                "templateUrl": "app\/components\/form\/fields\/dynamicList.html",
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.baseBranch}}",
+                                "_previousName": "baseB",
+                                "playbookField": true,
+                                "lengthConstraint": true,
+                                "allowedGridColumn": false,
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "contentRepository",
+                                "type": "string",
+                                "label": "Content Repository",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": false,
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.contentRepoName}}",
+                                "_previousName": "contentRepo",
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            },
+                            {
+                                "name": "productionSettingsRepository",
+                                "type": "string",
+                                "label": "Production Settings Repository",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": true,
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.prodSettingsRepoName}}",
+                                "_previousName": "productionSettingsReposito",
+                                "visibilityQuery": {
+                                    "sort": [],
+                                    "limit": 30,
+                                    "logic": "AND",
+                                    "filters": [
+                                        {
+                                            "type": "primitive",
+                                            "field": "productionSettingsRepository",
+                                            "value": "true",
+                                            "operator": "isnull",
+                                            "_operator": "isnull"
+                                        }
+                                    ]
+                                },
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false,
+                                "_addVisibilityConditions": true
+                            },
+                            {
+                                "name": "developmentSettingsRepository",
+                                "type": "string",
+                                "label": "Development Settings Repository",
+                                "tooltip": "",
+                                "dataType": "text",
+                                "formType": "text",
+                                "required": true,
+                                "_expanded": true,
+                                "defaultValue": "{{vars.input.records[0].configurationParameters.devSettingsRepoName}}",
+                                "_previousName": "developmentSettingsRepo",
+                                "jinjaExpressionView": true,
+                                "useRecordFieldDefault": false
+                            }
+                        ]
+                    }
+                },
+                "record": "{{ vars.input.records[0][\"@id\"] }}",
+                "agent_id": null,
+                "resources": "change_management",
+                "is_approval": false,
+                "owner_detail": {
+                    "isAssigned": false,
+                    "emailRecipients": ""
+                },
+                "isRecordLinked": true,
+                "step_variables": [],
+                "response_mapping": {
+                    "options": [
+                        {
+                            "option": "Submit",
+                            "primary": true,
+                            "step_iri": "\/api\/3\/workflow_steps\/da1693d1-670c-4942-bd7f-b12d24599bfd"
+                        }
+                    ],
+                    "duplicateOption": false,
+                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
+                },
+                "email_notification": {
+                    "enabled": false,
+                    "smtpParameters": []
+                },
+                "customEmailExternal": false,
+                "inline_channel_list": [],
+                "external_channel_list": [],
+                "unauthenticated_input": false,
+                "external_email_subject": null,
+                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
+                "custom_email_body_external": null,
+                "external_email_attachments": null
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+            "group": null,
+            "uuid": "5017112d-8599-4690-8d48-02faad02c93c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "b0dd85ad-d5a7-4a2c-a415-ad333af98a82",
+                "title": "Update Configuration Parameters",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>Initiating Tasks:<\/strong> Update Source Control Configuration<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
+                "resources": [
+                    "change_management"
+                ],
+                "__triggerLimit": true,
+                "inputVariables": [],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "triggerOnSource": true,
+                "displayConditions": {
+                    "change_management": {
+                        "sort": [],
+                        "limit": 30,
+                        "logic": "AND",
+                        "filters": [
+                            {
+                                "type": "primitive",
+                                "field": "title",
+                                "value": "Source Control Settings",
+                                "operator": "eq",
+                                "_operator": "eq"
+                            },
+                            {
+                                "type": "array",
+                                "field": "environment",
+                                "value": [
+                                    "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
+                                    "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
+                                ],
+                                "module": "environment",
+                                "display": "",
+                                "operator": "in",
+                                "template": "multiselectpicklist",
+                                "OPERATOR_KEY": "$",
+                                "useInOperator": true,
+                                "previousOperator": "in",
+                                "previousTemplate": "multiselectpicklist"
+                            }
+                        ]
+                    }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": false,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
+                "singleRecordExecution": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "6c412126-9186-44a4-b8b9-ae1ea35de86b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Source Control Configuration",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>Completed Tasks:<\/strong> Update Source Control Configuration<\/p>",
+                    "records": "",
+                    "parentstepid": "\/api\/3\/workflow_steps\/6c412126-9186-44a4-b8b9-ae1ea35de86b"
+                },
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
+                    "configurationParameters": "{{vars.updated_config}}"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "8e5bbf53-11f4-4157-8f77-6dcc0b0c0d9e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Status as In Progress",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "status": "\/api\/3\/picklists\/7f0263bf-29ab-4453-aefe-41d20f0fe9c3"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "5cc5744b-6e90-47d6-b470-81a74c2966d7"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration Parameters -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/da1693d1-670c-4942-bd7f-b12d24599bfd",
+            "sourceStep": "\/api\/3\/workflow_steps\/5017112d-8599-4690-8d48-02faad02c93c",
+            "label": "Submit",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "73e93325-b07a-495b-bc68-20606fafb28c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Update Source Control Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/8e5bbf53-11f4-4157-8f77-6dcc0b0c0d9e",
+            "sourceStep": "\/api\/3\/workflow_steps\/da1693d1-670c-4942-bd7f-b12d24599bfd",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2f40803d-6005-453d-9db6-7e5f88f634f4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Update Status as In Progress",
+            "targetStep": "\/api\/3\/workflow_steps\/5cc5744b-6e90-47d6-b470-81a74c2966d7",
+            "sourceStep": "\/api\/3\/workflow_steps\/6c412126-9186-44a4-b8b9-ae1ea35de86b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1cd3306a-1ac3-4aa8-9d2b-032c19ae2088"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Status as In Progress -> Configuration Parameters",
+            "targetStep": "\/api\/3\/workflow_steps\/5017112d-8599-4690-8d48-02faad02c93c",
+            "sourceStep": "\/api\/3\/workflow_steps\/5cc5744b-6e90-47d6-b470-81a74c2966d7",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "8477183b-a88e-40cf-a738-c8c7b5422a52"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
+    "isEditable": false,
+    "uuid": "44b750e6-8606-4c48-8bb6-43beea85b09e",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "CICD",
+        "ManualTrigger"
+    ]
+}


### PR DESCRIPTION
1195394 | Added cicd_config Global Variable to Change Management
- The cicd_config global variable has been moved into the Configuration Parameters field of the Change Management module.
As a result, the following playbooks were updated:
   - Closed the specified change request
   - Configure Source Control
   - Create a Request (Issue)
   - Create Pull Request
   - Create Release
   - Evaluate Git Sync Drift
   - Fetch Open Requests (Issues)
   - Get Source Control Connector Configuration
   - Merge Pull Request
   - Pull Latest Content from Source Control
   - Push Change to Source Control
   - Push Initial Production Environment Content
   - Retrieve Source Control Sync Status
   - Review and Apply Latest Content
   - Save FortiSOAR Settings
   - Set Source Control Username
   - Setup CICD Environment
   - Setup Development Environment


- 1009779 | Enhancement: Change Management Tab Visibility
   - Issue: Users could see Production/Development tabs before completing the "Set Source Control" step.
   - Resolution:
      - Modified the Change Management List Layout.
      - Removed the Key Store record visibility condition.
      - Added visibility conditions based on Change Management record status:
         - Production Tab:
            - Displayed when: title = "Setup the Source Control for Production Environment" and status = Completed
         - Development Tab:
            - Displayed when:
            (title = "Setup the Source Control for Production Environment" and status = Completed)
            or
            (title = "Setup the Development Environment" and status = Completed)


- 1195397 | Updated: Get Source Control Connector Configuration Playbook
   - The "Retrieve Source Control Sync Status" playbook is triggered by the "Ingest_Source-Control-Sync-Status (CICD)" schedule.
   - This playbook internally calls "Get Source Control Connector Configuration" to retrieve the connector config for the logged-in user. However, when triggered via a schedule, the currentUser field is not available in the playbook environment.
   - To handle this, we've updated the Retrieve Source Control Sync Status playbook to perform additional API calls to obtain the user context.


- 1195398 | Removed: Key Store Dependency
   - Previously, the key store record "CICD FortiSOAR Environment" was used to determine the selected environment during setup.
   - Now, the environment tab visibility is handled using Change Management record status, removing the need for the key store dependency.
   - Accordingly, the "Setup CICD Environment" playbook was updated to stop generating the key store record.


- 1195399 | Updated: Setup CICD Environment Playbook
   - Removed logic to create the "CICD FortiSOAR Environment" Key Store record
   - Now dynamically identifies pluggable source control playbooks from the associated sample collection


- 1193330 | Move CICD Config to Change Management Record
   - Added a new configurationParameters field in the Change Management module to store the cicd_config values
   - This change enables users to easily view and modify source control settings as needed
   - Introduced a new playbook, "Update Source Control Configuration", allowing users to update these settings
   - This playbook is triggered using the "Source Control Settings" record