### PR TITLE
Enhancements

### DIFF
--- a/modules/change_management/detail-layout.json
+++ b/modules/change_management/detail-layout.json
@@ -3326,6 +3326,78 @@
                                                                                                                 }
                                                                                                             }
                                                                                                         }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "sectionHeader",
+                                                                                                        "config": {
+                                                                                                            "wid": "37a516c2-4f29-4d47-8b68-3183620da175",
+                                                                                                            "query": {
+                                                                                                                "filters": [],
+                                                                                                                "sort": [],
+                                                                                                                "limit": 10
+                                                                                                            },
+                                                                                                            "editorType": "html",
+                                                                                                            "sectionText": "<p class=\"font-size-14  muted-80\"><strong>Reset CI\/CD Configuration<\/strong><\/p>\n<p class=\"font-size-13  muted-80\"><strong>Reset the current CI\/CD setup to its original base state.<\/strong><br>This will clear any existing production and\/or development environment configurations. After resetting, you can re-run the configuration wizard to set up your environments correctly.<\/p>",
+                                                                                                            "visibility": {
+                                                                                                                "conditionalVisibility": true,
+                                                                                                                "filter": {
+                                                                                                                    "sort": [],
+                                                                                                                    "limit": 30,
+                                                                                                                    "logic": "AND",
+                                                                                                                    "filters": [
+                                                                                                                        {
+                                                                                                                            "field": "type",
+                                                                                                                            "operator": "eq",
+                                                                                                                            "value": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                                                                                                                            "_value": {
+                                                                                                                                "display": "Setup",
+                                                                                                                                "itemValue": "Setup",
+                                                                                                                                "@id": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c"
+                                                                                                                            },
+                                                                                                                            "type": "object"
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            "field": "status",
+                                                                                                                            "operator": "eq",
+                                                                                                                            "value": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                                                                                                            "_value": {
+                                                                                                                                "display": "Completed",
+                                                                                                                                "itemValue": "Completed",
+                                                                                                                                "@id": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d"
+                                                                                                                            },
+                                                                                                                            "type": "object"
+                                                                                                                        }
+                                                                                                                    ]
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "playbookButtons-1.1.1",
+                                                                                                        "config": {
+                                                                                                            "wid": "5966d203-8784-495c-9411-16d5366c0e92",
+                                                                                                            "widgetName": "Playbook Execution Wizard",
+                                                                                                            "selectedPlaybooksWithRecord": [
+                                                                                                                {
+                                                                                                                    "name": "Reset Environment",
+                                                                                                                    "uuid": "16b34080-5f0a-42dc-828e-9529735e3f42",
+                                                                                                                    "actionTriggerName": "Reset Environment",
+                                                                                                                    "collectionName": "01 - Drafts",
+                                                                                                                    "icon": "icon icon-resolve"
+                                                                                                                }
+                                                                                                            ],
+                                                                                                            "showPrimaryButton": true,
+                                                                                                            "showExecutionProgress": true,
+                                                                                                            "selectedExecutionWizardPlaybooks": [
+                                                                                                                {
+                                                                                                                    "name": "Reset Environment",
+                                                                                                                    "uuid": "16b34080-5f0a-42dc-828e-9529735e3f42",
+                                                                                                                    "actionTriggerName": "Reset Environment",
+                                                                                                                    "collectionName": "01 - Drafts",
+                                                                                                                    "icon": "icon icon-resolve"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
                                                                                                     }
                                                                                                 ],
                                                                                                 "style": "col-lg-6"

--- a/playbooks/02 - Use Case - CICD/Reset Environment.json
+++ b/playbooks/02 - Use Case - CICD/Reset Environment.json
@@ -1,0 +1,657 @@
+{
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "Reset Environment",
+    "aliasName": null,
+    "tag": null,
+    "description": "Resets the current CI\/CD configuration to default, clearing any set environments. Allows you to restart the setup wizard to configure production and development environments.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/4c58fed3-9e16-451a-9528-0be2b71acda4",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/cfa18cff-29e5-418d-b2c4-de4bc00881a6",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "thread": false,
+                    "content": "<p>Reseting CI\/CD Configurations ..&nbsp;<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}",
+                    "parentstepid": "\/api\/3\/workflow_steps\/cfa18cff-29e5-418d-b2c4-de4bc00881a6"
+                },
+                "setup_records": "[\"Setup the Development Environment\", \"Setup the Source Control for Production Environment\"]"
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "0fb662eb-8ebf-483f-b713-122fb56d97cb"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Delete CICD Environment Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/{{vars.cicd_env_id}}\/?format=json",
+                    "body": "",
+                    "method": "DELETE"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "ignore_errors": true,
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "cicd_env_id": "{{(vars.steps.Find_CICD_Environment_Global_Variable.data[\"hydra:member\"] | json_query(\"[?name=='cicd_env'].id\"))[0] | string}}"
+                }
+            },
+            "status": null,
+            "top": "960",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "487655f6-db46-4c15-bdc8-a803596117ab"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find CICD Environment Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?offset=0&limit=2147483647",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "ignore_errors": false,
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "cicd_env_id": "{{(vars.steps.Find_CICD_Environment_Global_Variable.data[\"hydra:member\"] | json_query(\"[?name=='cicd_env'].id\"))[0] | string}}"
+                }
+            },
+            "status": null,
+            "top": "840",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "f52ba69b-45bd-483d-b1d7-855fc1d7ba83"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Development Type Environment",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "type",
+                            "value": "\/api\/3\/picklists\/dc57442c-3d52-43a0-aa19-ed2898e30ff7",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/dc57442c-3d52-43a0-aa19-ed2898e30ff7",
+                                "display": "Development",
+                                "itemValue": "Development"
+                            },
+                            "operator": "eq"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "1c744f8a-2068-4231-8664-dbb8bac201d4"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Production Type Environment",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "object",
+                            "field": "type",
+                            "value": "\/api\/3\/picklists\/409b289f-33f5-423f-9174-24bc8628cc4a",
+                            "_value": {
+                                "@id": "\/api\/3\/picklists\/409b289f-33f5-423f-9174-24bc8628cc4a",
+                                "display": "Production",
+                                "itemValue": "Production"
+                            },
+                            "operator": "eq"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "1e7de859-8258-4a77-8eb8-cf49175360b2"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Setup Environments",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "{{vars.setup_records}}",
+                            "operator": "in",
+                            "_operator": "in"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "8c37cc59-41a1-42d8-9056-98897a2f35ec"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "No Operation",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "305e332e-1c65-421c-90d2-81539e3d8a80"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Reset to Base Configuration",
+            "description": null,
+            "arguments": {
+                "type": "InputBased",
+                "input": {
+                    "schema": {
+                        "title": "Are you sure you want to reset?",
+                        "description": "This will reset the current CI\/CD setup to its base state, clearing all existing environment configurations. \nYou will need to re-run the configuration wizard to set up your production and\/or development environments again.\n**This action cannot be undone.**",
+                        "inputVariables": []
+                    }
+                },
+                "record": "{{ vars.input.records[0][\"@id\"] }}",
+                "agent_id": null,
+                "resources": "change_management",
+                "is_approval": false,
+                "owner_detail": {
+                    "isAssigned": false,
+                    "emailRecipients": ""
+                },
+                "isRecordLinked": true,
+                "step_variables": [],
+                "response_mapping": {
+                    "options": [
+                        {
+                            "option": "Reset",
+                            "primary": true,
+                            "step_iri": "\/api\/3\/workflow_steps\/0afc2c08-a80a-4d1d-b77a-832e808934f3"
+                        },
+                        {
+                            "option": "Cancel",
+                            "step_iri": "\/api\/3\/workflow_steps\/305e332e-1c65-421c-90d2-81539e3d8a80"
+                        }
+                    ],
+                    "duplicateOption": false,
+                    "customSuccessMessage": "Awaiting Playbook resumed successfully."
+                },
+                "email_notification": {
+                    "enabled": false,
+                    "smtpParameters": []
+                },
+                "customEmailExternal": false,
+                "inline_channel_list": [],
+                "external_channel_list": [],
+                "unauthenticated_input": false,
+                "external_email_subject": null,
+                "internal_email_subject": "A FortiSOAR playbook is requesting your input",
+                "custom_email_body_external": null,
+                "external_email_attachments": null
+            },
+            "status": null,
+            "top": "165",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+            "group": null,
+            "uuid": "893256d0-8073-440b-979f-7030b3cc3c62"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Status as In Progress",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "status": "\/api\/3\/picklists\/7f0263bf-29ab-4453-aefe-41d20f0fe9c3"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "0afc2c08-a80a-4d1d-b77a-832e808934f3"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Status to Completed",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p>Completed Task: Reset CI\/CD Environment<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}",
+                    "parentstepid": "\/api\/3\/workflow_steps\/0fb662eb-8ebf-483f-b713-122fb56d97cb"
+                },
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1080",
+            "left": "480",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "b540b7a2-5810-4271-872f-6870a338c450"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "route": "3c65ec73-f44b-4d2f-9e14-db33433a073d",
+                "title": "Reset CI\/CD Environment",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p>Initiating Task: Reset CI\/CD Environment<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
+                "resources": [
+                    "change_management"
+                ],
+                "__triggerLimit": true,
+                "inputVariables": [],
+                "step_variables": {
+                    "input": {
+                        "params": [],
+                        "records": "{{vars.input.records}}"
+                    }
+                },
+                "triggerOnSource": true,
+                "displayConditions": {
+                    "change_management": {
+                        "sort": [],
+                        "limit": 30,
+                        "logic": "AND",
+                        "filters": [
+                            {
+                                "type": "object",
+                                "field": "type",
+                                "value": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                                    "display": "Setup",
+                                    "itemValue": "Setup"
+                                },
+                                "operator": "eq"
+                            },
+                            {
+                                "type": "object",
+                                "field": "status",
+                                "value": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/eb7e156f-f599-4cf6-a12b-5484c1bc414d",
+                                    "display": "Completed",
+                                    "itemValue": "Completed"
+                                },
+                                "operator": "eq"
+                            }
+                        ]
+                    }
+                },
+                "executeButtonText": "Execute",
+                "noRecordExecution": false,
+                "showToasterMessage": {
+                    "visible": false,
+                    "messageVisible": true
+                },
+                "triggerOnReplicate": false,
+                "singleRecordExecution": true
+            },
+            "status": null,
+            "top": "30",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
+            "group": null,
+            "uuid": "cfa18cff-29e5-418d-b2c4-de4bc00881a6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Development Type Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Production_Type_Environment}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "_showJson": true,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "21709804-0225-45f2-9f67-2839a8ff4b1f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Production Type Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Production_Type_Environment}}",
+                    "__bulk": true,
+                    "condition": "",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "8d11a39a-c016-4885-86a3-c8bc6dd53e8e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Setup Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "{{null}}",
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
+                    "environment": "\/api\/3\/picklists\/5ec65649-9da5-4fcd-8198-48dcb548cf41"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "35627175-cca5-4e84-b1da-8d888dccc84a"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Find Development Type Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/1c744f8a-2068-4231-8664-dbb8bac201d4",
+            "sourceStep": "\/api\/3\/workflow_steps\/0fb662eb-8ebf-483f-b713-122fb56d97cb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "bb198249-c2aa-4aff-91cb-227fada74823"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Find Production Type Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/1e7de859-8258-4a77-8eb8-cf49175360b2",
+            "sourceStep": "\/api\/3\/workflow_steps\/0fb662eb-8ebf-483f-b713-122fb56d97cb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "8a4118fc-e83b-474d-a4f8-d9c329aa8c9b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Find Setup Environments",
+            "targetStep": "\/api\/3\/workflow_steps\/8c37cc59-41a1-42d8-9056-98897a2f35ec",
+            "sourceStep": "\/api\/3\/workflow_steps\/0fb662eb-8ebf-483f-b713-122fb56d97cb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "cc547272-642a-4f1d-8dda-b349e55bd5a7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Delete CICD Environment Global Variable -> Set Status to Completed",
+            "targetStep": "\/api\/3\/workflow_steps\/b540b7a2-5810-4271-872f-6870a338c450",
+            "sourceStep": "\/api\/3\/workflow_steps\/487655f6-db46-4c15-bdc8-a803596117ab",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b1484903-359e-48cb-bd4a-9ed7276ce10f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find CICD Environment Global Variable -> Delete CICD Environment Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/487655f6-db46-4c15-bdc8-a803596117ab",
+            "sourceStep": "\/api\/3\/workflow_steps\/f52ba69b-45bd-483d-b1d7-855fc1d7ba83",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e508d621-4bb2-462f-a873-05da9b59d338"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Development Type Environment -> Copy of Update Production Type Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/21709804-0225-45f2-9f67-2839a8ff4b1f",
+            "sourceStep": "\/api\/3\/workflow_steps\/1c744f8a-2068-4231-8664-dbb8bac201d4",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1807468c-b15a-4f1a-8174-ff9797e253c1"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Production Type Environment -> Update Production Type Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/8d11a39a-c016-4885-86a3-c8bc6dd53e8e",
+            "sourceStep": "\/api\/3\/workflow_steps\/1e7de859-8258-4a77-8eb8-cf49175360b2",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ad743ec5-b493-4720-8c44-92c3c1475203"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Setup Environments -> Update Setup Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/35627175-cca5-4e84-b1da-8d888dccc84a",
+            "sourceStep": "\/api\/3\/workflow_steps\/8c37cc59-41a1-42d8-9056-98897a2f35ec",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "bc183d6d-4f37-4ec2-91ff-0f4676250c3f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Reset to Base Configuration -> No Operation",
+            "targetStep": "\/api\/3\/workflow_steps\/305e332e-1c65-421c-90d2-81539e3d8a80",
+            "sourceStep": "\/api\/3\/workflow_steps\/893256d0-8073-440b-979f-7030b3cc3c62",
+            "label": "Cancel",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d088dd85-8b1d-47b5-ad44-a147bf730d2d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Reset to Base Configuration -> Set Status as In Progress",
+            "targetStep": "\/api\/3\/workflow_steps\/0afc2c08-a80a-4d1d-b77a-832e808934f3",
+            "sourceStep": "\/api\/3\/workflow_steps\/893256d0-8073-440b-979f-7030b3cc3c62",
+            "label": "Reset",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4a3127ba-2dcc-4943-aa1c-8acca73efbdb"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Set Status as In Progress -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/0fb662eb-8ebf-483f-b713-122fb56d97cb",
+            "sourceStep": "\/api\/3\/workflow_steps\/0afc2c08-a80a-4d1d-b77a-832e808934f3",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "43a9abe4-6407-4cb7-8ef2-4e54aef3be34"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Reset to Base Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/893256d0-8073-440b-979f-7030b3cc3c62",
+            "sourceStep": "\/api\/3\/workflow_steps\/cfa18cff-29e5-418d-b2c4-de4bc00881a6",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e12ea56a-5ff8-41d1-94ef-5e114bb39b66"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Development Type Environment -> Find CICD Environment Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/f52ba69b-45bd-483d-b1d7-855fc1d7ba83",
+            "sourceStep": "\/api\/3\/workflow_steps\/21709804-0225-45f2-9f67-2839a8ff4b1f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0d5ecd05-7cf9-4974-8fa7-0df9a2ca31dc"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Production Type Environment -> Find CICD Environment Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/f52ba69b-45bd-483d-b1d7-855fc1d7ba83",
+            "sourceStep": "\/api\/3\/workflow_steps\/8d11a39a-c016-4885-86a3-c8bc6dd53e8e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2ebfb3b5-0b25-485e-97d9-3240cb8f61f8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Setup Environment -> Find CICD Environment Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/f52ba69b-45bd-483d-b1d7-855fc1d7ba83",
+            "sourceStep": "\/api\/3\/workflow_steps\/35627175-cca5-4e84-b1da-8d888dccc84a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "76379814-f453-469f-b864-21d7a86c4d1c"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
+    "isEditable": false,
+    "uuid": "16b34080-5f0a-42dc-828e-9529735e3f42",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "CICD",
+        "ManualTrigger"
+    ]
+}


### PR DESCRIPTION
1201753 | Reset the current CI/CD setup back to its base state.
   - Added new feature on Setup records i.e. Development or Production to reset the current CI/CD setup back to its base state. This task will only visible when type of record is Setup and Status is Completed.
   - After deletion the `cicd_env` global variable 
   - Added new playbook `Reset Environment` playbook to reset the current CI/CD setup back to its base state.
   
<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/661270dd-69cf-48c6-a2ac-ced64e1ec9d4" />
