### PR TITLE
BugFixes

### DIFF
--- a/playbooks/02 - Use Case - CICD/Create Pull Request.json
+++ b/playbooks/02 - Use Case - CICD/Create Pull Request.json
@@ -78,6 +78,7 @@
             "name": "Add PR Reviewers",
             "description": null,
             "arguments": {
+                "when": "{{vars.steps.Specify_PR_Title_and_Comments.input.reviewersName != None}}",
                 "arguments": {
                     "connector_config_id": "{{vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}",
                     "add_reviewers_for_pr_params": "{\"org_name\" : \"{{vars.cicdConfig.organizationName}}\",\"repo_name\": \"{{vars.repo_name}}\",\"pull_number\": \"{{vars.steps.Create_Pull_Request.data.number}}\",\"reviewers\": \"{{vars.steps.Specify_PR_Title_and_Comments.input.reviewersName}}\"}"

--- a/playbooks/02 - Use Case - CICD/Reset Environment.json
+++ b/playbooks/02 - Use Case - CICD/Reset Environment.json
@@ -406,7 +406,9 @@
                     "batch_size": 100
                 },
                 "resource": {
-                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
+                    "results": "<p>{{null}}<\/p>",
+                    "lastCommitID": "{{null}}"
                 },
                 "_showJson": true,
                 "operation": "Append",
@@ -437,7 +439,9 @@
                     "batch_size": 100
                 },
                 "resource": {
-                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
+                    "results": "<p>{{null}}<\/p>",
+                    "lastCommitID": "{{null}}"
                 },
                 "operation": "Append",
                 "collection": "{{vars.item['@id']}}",
@@ -470,7 +474,9 @@
                 "resource": {
                     "type": "{{null}}",
                     "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
-                    "environment": "\/api\/3\/picklists\/5ec65649-9da5-4fcd-8198-48dcb548cf41"
+                    "results": "<p>{{null}}<\/p>",
+                    "environment": "\/api\/3\/picklists\/5ec65649-9da5-4fcd-8198-48dcb548cf41",
+                    "lastCommitID": "{{null}}"
                 },
                 "_showJson": false,
                 "operation": "Append",


### PR DESCRIPTION
- 1204167 | "Add Reviewers for a Pull Request" playbook fails if reviewer is not selected.
    - `RCA`: While creating PR if reviewers are not selected even though playbook goes to add the reviewers 
    - `Solution`: Added the condition if reviewers are not selected then do not call the add reviewer playbook 

- If user `Reset Environment` then `result` and `lastCommitID` should also reset