### PR TITLE
BugFixes

### DIFF
--- a/playbooks/02 - Use Case - CICD/Fetch Latest Changes.json
+++ b/playbooks/02 - Use Case - CICD/Fetch Latest Changes.json
@@ -67,7 +67,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
+            "top": "705",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -79,10 +79,11 @@
             "description": null,
             "arguments": {
                 "cicd_env": "{{globalVars.cicd_env}}",
-                "cicd_config": "{{globalVars.cicd_config | toDict}}"
+                "org_name": "{{vars.cicd_config.organizationName}}",
+                "repo_name": "{{vars.cicd_config.contentRepoName}}"
             },
             "status": null,
-            "top": "300",
+            "top": "435",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -111,7 +112,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
@@ -124,7 +125,7 @@
             "arguments": {
                 "arguments": {
                     "connector_config_id": "{{vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}",
-                    "list_repo_issues_params": "{\"org_name\": \"{{vars.cicd_config.content.split('\/')[-2]}}\",\n\"repo_name\": \"{{vars.cicd_config.content.split('\/')[-1]}}\",\n\"state\": \"closed\",\n\"since\": \"{{vars.input.records[0].lastBuildDeployedOn}}\"\n}"
+                    "list_repo_issues_params": "{\"org_name\": \"{{vars.org_name}}\",\n\"repo_name\": \"{{vars.repo_name}}\",\n\"state\": \"closed\",\n\"since\": \"{{vars.input.records[0].lastBuildDeployedOn}}\"\n}"
                 },
                 "apply_async": false,
                 "step_variables": [],
@@ -133,11 +134,65 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"ListRepositoryIssue\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "435",
+            "top": "570",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "c3ed55c4-e17d-43d9-b377-3284f30f5fa4"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Settings",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "array",
+                            "field": "environment",
+                            "value": [
+                                "d4ff078d-7692-4737-b45b-00990e949651",
+                                "48b9f120-34bc-4884-b886-85e82321684b"
+                            ],
+                            "module": "environment",
+                            "display": "",
+                            "operator": "in",
+                            "template": "multiselectpicklist",
+                            "enableJinja": true,
+                            "OPERATOR_KEY": "$",
+                            "useInOperator": true,
+                            "previousOperator": "in",
+                            "previousTemplate": "multiselectpicklist"
+                        }
+                    ],
+                    "__selectFields": [
+                        "configurationParameters",
+                        "environment"
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "checkboxFields": true,
+                "step_variables": {
+                    "cicd_env": "{{globalVars.cicd_env}}",
+                    "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}"
+                }
+            },
+            "status": null,
+            "top": "300",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "3cca9e64-61a2-485e-8833-a6fe9545276b"
         },
         {
             "@type": "WorkflowStep",
@@ -209,7 +264,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -219,13 +274,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/046279a8-a619-427d-bec4-b1cab544dcec",
+            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/3cca9e64-61a2-485e-8833-a6fe9545276b",
             "sourceStep": "\/api\/3\/workflow_steps\/18e6cd9d-0268-46be-8db0-c32520770b0b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "2022ead0-ad16-46a2-b087-2daae2b80779"
+            "uuid": "c351c2c8-d7b5-40d7-af5a-b52819963df2"
         },
         {
             "@type": "WorkflowRoute",
@@ -245,7 +300,7 @@
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "de42f8c6-6ea2-4bcc-a1d7-8ffb836e5a76"
+            "uuid": "1fd50708-a2e1-4b3f-9a1b-9adad5155b0f"
         },
         {
             "@type": "WorkflowRoute",
@@ -256,6 +311,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "27e5001e-da1a-4905-aa72-4c6e56166e40"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Settings -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/046279a8-a619-427d-bec4-b1cab544dcec",
+            "sourceStep": "\/api\/3\/workflow_steps\/3cca9e64-61a2-485e-8833-a6fe9545276b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "44bb82fd-017d-43b8-b242-925c0a8a80e1"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Merge Pull Request.json
+++ b/playbooks/02 - Use Case - CICD/Merge Pull Request.json
@@ -746,7 +746,7 @@
             "name": "Update Last Commit ID",
             "description": null,
             "arguments": {
-                "when": "{{vars.steps.Get_Apply_Latest_Content_Record | length > 0}}",
+                "when": "{{vars.steps.Get_Apply_Latest_Content_Record | length > 0 and vars.cicd_env | length == 2}}",
                 "resource": {
                     "lastCommitID": "{{vars.steps.Merge_Pull_Request.data.sha}}"
                 },

--- a/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
@@ -400,6 +400,7 @@
             "name": "Get Latest Commit",
             "description": null,
             "arguments": {
+                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
                 "arguments": {
                     "get_commit_params": "{\n\"org_name\": \"{{vars.org_name}}\",\n\"repo_name\": \"{{vars.repo_name}}\",\n\"commit_ref\": \"{{vars.base_branch_name}}\",\n\"repo_type\": \"Organization\"\n}",
                     "connector_config_id": "{{vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}"
@@ -819,9 +820,10 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Deployed Date",
+            "name": "Update Deployed Details",
             "description": null,
             "arguments": {
+                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
                 "message": {
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",

--- a/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
+++ b/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
@@ -167,7 +167,7 @@
                     "recordTags": "Overwrite"
                 },
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Dev Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
+                    "repo_name": "{% if vars.request.selectedRepository == \"Development Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 }
             },
             "status": null,
@@ -301,7 +301,7 @@
                     {
                         "option": "Prod",
                         "step_iri": "\/api\/3\/workflow_steps\/8c579dc8-32b0-4e59-a147-1f41a2825549",
-                        "condition": "{{ vars.request.selectedRepository\t== \"Production Content\" }}",
+                        "condition": "{{ \"Production\" in vars.request.selectedRepository }}",
                         "step_name": "Prod Commit Status"
                     },
                     {
@@ -341,7 +341,7 @@
                     "recordTags": "Overwrite"
                 },
                 "step_variables": {
-                    "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Prod Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
+                    "repo_name": "{% if vars.request.selectedRepository == \"Production Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}"
                 }
             },
             "status": null,
@@ -632,7 +632,7 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "24963415-4057-4fd5-bbe5-bf7d6bfa059d",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Update Apply Latest Content Commit Details.json
+++ b/playbooks/02 - Use Case - CICD/Update Apply Latest Content Commit Details.json
@@ -116,6 +116,7 @@
             "name": "Get Latest Commit",
             "description": null,
             "arguments": {
+                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
                 "message": {
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -196,18 +197,9 @@
             "name": "Update Commit Details",
             "description": null,
             "arguments": {
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p>Completed Task: Apply Latest Content<\/p>",
-                    "records": "{{vars.request.record['@id']}}",
-                    "parentstepid": "\/api\/3\/workflow_steps\/3ffce50a-6b49-4b02-a073-2d98209ed88a"
-                },
+                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
                 "resource": {
-                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293",
-                    "commitStatus": "<h5 class=\"margin-top-negative-1\" style=\"color: #28a745;\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
+                    "commitStatus": "<h5 style=\"color: #28a745;\" class=\"margin-top-negative-1\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
                     "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}",
                     "lastBuildDeployedOn": "{%if vars.repo_name == vars.cicd_config.contentRepoName %}{{arrow.utcnow().int_timestamp}}{%else%}{{vars.request.record.lastBuildDeployedOn}}{%endif%}"
                 },
@@ -226,6 +218,39 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "d35e03ff-37ee-472e-84b2-06f336876446"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Status as Pending",
+            "description": null,
+            "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p>Completed Task: Apply Latest Content<\/p>",
+                    "records": "{{vars.request.record['@id']}}",
+                    "parentstepid": "\/api\/3\/workflow_steps\/d35e03ff-37ee-472e-84b2-06f336876446"
+                },
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "operation": "Append",
+                "collection": "{{vars.request.record['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "72710f60-3c16-4465-a0a9-67f56c9a43a6"
         },
         {
             "@type": "WorkflowStep",
@@ -330,6 +355,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "fb194e4d-017f-495b-b69e-474dd0bd92fe"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Commit Details -> Update Status as Pending",
+            "targetStep": "\/api\/3\/workflow_steps\/72710f60-3c16-4465-a0a9-67f56c9a43a6",
+            "sourceStep": "\/api\/3\/workflow_steps\/d35e03ff-37ee-472e-84b2-06f336876446",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a7a0973c-5e10-45c7-95ea-a0b119ba747b"
         }
     ],
     "groups": [],


### PR DESCRIPTION
- 1206641 | "Fetch Latest Changes" Playbook Uses Global Variable cicd_config
    - `Root Cause (RCA)`: The cicd_config global variable was recently moved to the Configuration Parameters field within the Change Management module. However, the playbook is still referencing the outdated global variable.
    - `Solution`: The playbook has been updated to retrieve the Source Control Settings from the Change Management record and assign them to the cicd_config variable for further use.

- 1206574 | "Production Content" is Applied Even When "Production Setting" is Selected
   - `Root Cause (RCA)`: When applying the latest configurations from either the production or development environment, the user should be able to specify whether they want to apply Content or Settings. However, even if the user selects "Settings," the content was being applied incorrectly.
   - `Solution`: The Jinja templates were updated to properly evaluate the user's selection and ensure that only the chosen type (Content or Settings) is applied based on the specified environment.


- 1203410 | "Last Commit ID" and "Commit Status" is updated after applying the "Production/Development Setting" too.
    - `RCA`: Need to check if selected repository is content then and then only update the "Last Commit ID" and "Commit Status"
    - `Solution`: added the condtion `vars.repo_name == "fortisoar-prod-content"` in `Get Latest Commit` and `Update Deployed Details` step in `Pull Latest Content from Source Control` and `Update Apply Latest Content Commit Details` playbook

- 1203407 | "Last Commit ID" Should Not Be Updated for Production-Only Setups When Using the "Merge Pull Request" Playbook
   - `Root Cause (RCA)`: The "Last Commit ID" is currently being updated even when the setup is configured as Production-only while running the "Merge Pull Request" playbook.
    - `Solution`: Modify the playbook logic so that the "Last Commit ID" is not updated for Production-only setups. It should only be updated if the setup includes both Production and Development environments when using the "Merge Pull Request" playbook.