### PR TITLE
Enhancements/BugFixes

### DIFF
--- a/playbooks/02 - Use Case - CICD/Create Release.json
+++ b/playbooks/02 - Use Case - CICD/Create Release.json
@@ -85,7 +85,7 @@
                 "cicd_env": "{{globalVars.cicd_env}}",
                 "cicd_config": "{{vars.cicd_config}}",
                 "release_name": "Release\/",
-                "release_number": "1.0",
+                "release_number": "1.0.0",
                 "source_control_web_url": "{{vars.cicd_config.source_control_url}}",
                 "prod_environment_record_iri": "\/api\/3\/change_management\/4be084b9-c5fe-4d42-943f-6bb2161d7157",
                 "release_initial_description": "Intial Commit",
@@ -277,7 +277,7 @@
                         "option": "Yes",
                         "step_iri": "\/api\/3\/workflow_steps\/87e28c72-85e0-48f8-ae2b-d11d659cf9d6",
                         "condition": "{{ vars.steps.Fetch_Release.data | length > 0 }}",
-                        "step_name": "Copy of Add comment for new release"
+                        "step_name": "Add Existing Release Comment"
                     },
                     {
                         "option": "No",
@@ -285,7 +285,8 @@
                         "step_iri": "\/api\/3\/workflow_steps\/93e3d5a7-bfbb-4b08-bd2e-4890c7cf1f7b",
                         "step_name": "Create Release"
                     }
-                ]
+                ],
+                "step_variables": []
             },
             "status": null,
             "top": "840",
@@ -423,7 +424,7 @@
             "name": "Is Release Exist -> Add comment for existing release",
             "targetStep": "\/api\/3\/workflow_steps\/87e28c72-85e0-48f8-ae2b-d11d659cf9d6",
             "sourceStep": "\/api\/3\/workflow_steps\/a30e6ec7-8628-450d-a612-992c6ca026e9",
-            "label": null,
+            "label": "Yes",
             "isExecuted": false,
             "group": null,
             "uuid": "69f95bae-1b98-4bec-a1f0-0812001a6afe"
@@ -433,7 +434,7 @@
             "name": "Is Release Exist -> Create Release",
             "targetStep": "\/api\/3\/workflow_steps\/93e3d5a7-bfbb-4b08-bd2e-4890c7cf1f7b",
             "sourceStep": "\/api\/3\/workflow_steps\/a30e6ec7-8628-450d-a612-992c6ca026e9",
-            "label": null,
+            "label": "No",
             "isExecuted": false,
             "group": null,
             "uuid": "d4c57e07-5f09-4074-92b1-ef9a143b5764"

--- a/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
+++ b/playbooks/02 - Use Case - CICD/Create a Request (Issue).json
@@ -351,7 +351,7 @@
                 "input": {
                     "schema": {
                         "title": "Action Required: Map Username",
-                        "description": "You must map the logged-in FortiSOAR user to a Source Control username using the \"Map Source Control Username\" operation before performing CI\/CD actions.",
+                        "description": "<h5>Warning: Connector or User Mapping Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector or is not mapped to a source control username.<\/p>",
                         "inputVariables": []
                     }
                 },

--- a/playbooks/02 - Use Case - CICD/Fetch Closed Requests (Issues).json
+++ b/playbooks/02 - Use Case - CICD/Fetch Closed Requests (Issues).json
@@ -24,7 +24,7 @@
                     {
                         "option": "Yes",
                         "step_iri": "\/api\/3\/workflow_steps\/e385fd71-82fe-493b-a04b-45da8489e723",
-                        "condition": "{{ vars.cicd_config | length > 0 }}",
+                        "condition": "{{ vars.cicd_config | length > 0 and vars.steps.Check_Source_Control_Connector_Configuration.config_id != None }}",
                         "step_name": "Configuration"
                     },
                     {

--- a/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Get Source Control Connector Configuration.json
@@ -17,82 +17,18 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Get All FSR Users",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/3\/people?$limit=2147483647&$orderby=%2Bfirstname,%2Blastname,-modifyDate&&__selectFields=userId",
-                    "body": "",
-                    "method": "GET"
-                },
-                "version": "3.6.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "userId": "{{vars.steps.Get_All_FSR_Users.data[\"hydra:member\"] | selectattr(\"@type\", \"equalto\", \"Person\") | map(attribute=\"userId\") | list}}"
-                }
-            },
-            "status": null,
-            "top": "435",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "b336e79a-0f1c-4c3d-9383-a84ed923299e"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get All FSR Users Auth",
-            "description": null,
-            "arguments": {
-                "params": {
-                    "iri": "\/api\/auth\/query\/users",
-                    "body": "{ \"users\":{{vars.userId}} }",
-                    "method": "POST"
-                },
-                "version": "3.6.0",
-                "connector": "cyops_utilities",
-                "operation": "make_cyops_request",
-                "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "logged_in_user_iri": "{% set uuid = (vars.steps.Get_All_FSR_Users_Auth.data.usersresp | selectattr(\"is_logged_in\", \"equalto\", true) | map(attribute=\"uuid\") | list)[0] %}{% set matched_users = vars.steps.Get_All_FSR_Users.data['hydra:member'] | selectattr(\"userId\", \"equalto\", uuid) | list %}{{ matched_users[0]['@id'] if matched_users else 'User not found' }}"
-                }
-            },
-            "status": null,
-            "top": "570",
-            "left": "475",
-            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
-            "group": null,
-            "uuid": "b6b0f6c8-0111-4786-9d2b-c9819b5c294a"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Get Current User Configuration",
             "description": null,
             "arguments": {
-                "current_user_source_control_connector_username": "{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name==connector_config.config.username %}{{connector_config.config.username}}{% break %}{% endif %}{% endfor %}",
-                "current_user_source_control_connector_config_id": "{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name==connector_config.config.username %}{{connector_config.config_id}}{% break %}{% endif %}{% endfor %}"
+                "current_user_source_control_connector_username": "{% set ns = namespace(match_found=false, matched_username=None) %}{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name.strip() == connector_config.config.username.strip() %}{% set ns.match_found = true %}{% set ns.matched_username = connector_config.config.username %}{% break %}{% endif %}{% endfor %}{% if ns.match_found %}{{ ns.matched_username }}{% else %}null{% endif %}",
+                "current_user_source_control_connector_config_id": "{% set ns = namespace(match_found=false) %}{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.logged_in_user_sc_name == connector_config.config.username %}{{ connector_config.config_id }}{% set ns.match_found = true %}{% break %}{% endif %}{% endfor %}{% if not ns.match_found %}null{% endif %}"
             },
             "status": null,
-            "top": "975",
-            "left": "125",
+            "top": "570",
+            "left": "485",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "2c4669a5-feca-4025-98f9-190c4ac2020c"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Get Logged User Details",
-            "description": null,
-            "arguments": {
-                "logged_in_user_sc_name": "{{((vars.currentUser or vars.request['currentUser'] ) | fromIRI).sourceControlUsername}}"
-            },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "25673a1d-3cc2-4c72-a35b-74fd209f7b1f"
         },
         {
             "@type": "WorkflowStep",
@@ -104,24 +40,50 @@
                     "body": "",
                     "method": "POST"
                 },
-                "version": "3.6.0",
+                "version": "3.7.0",
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",
-                "step_variables": {
-                    "is_schedule_triggered": "{% if (vars.currentUser == None or vars.request['currentUser'] == None) %}true{% else %}{% if \"\/api\/3\/appliances\/\" in vars.currentUser %}true{% else %}false{% endif %}{% endif %}"
-                }
+                "step_variables": []
             },
             "status": null,
             "top": "165",
-            "left": "300",
+            "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "d9154b92-9539-49a7-b722-cc6e7ae58174"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Is Connector Configure",
+            "name": "Is Connector Configured",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/38dd5b2a-6b7e-4cf9-b4f4-3ec961cf5b80",
+                        "condition": "{{ vars.current_user_source_control_connector_config_id != None }}",
+                        "step_name": "Return Output"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/83af27eb-b9e4-4338-98f9-a51f700bb19f",
+                        "step_name": "Return No Output"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "485",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "7b427db2-016f-4c58-af52-b2d259b79426"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Logged in User Mapped",
             "description": null,
             "arguments": {
                 "conditions": [
@@ -141,50 +103,22 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "300",
+            "top": "435",
+            "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "1b057294-590b-4a4d-b951-7b455c52c426"
         },
         {
             "@type": "WorkflowStep",
-            "name": "Is FSR Logged in Username Mapped",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/25673a1d-3cc2-4c72-a35b-74fd209f7b1f",
-                        "condition": "{{ vars.is_schedule_triggered == false }}",
-                        "step_name": "Get Logged User Details"
-                    },
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
-                        "step_name": "Get All FSR Users"
-                    }
-                ],
-                "step_variables": []
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "acc75bf1-5995-4f46-91db-151f6cc751ef"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Loggedin User Details",
             "description": null,
             "arguments": {
-                "logged_in_user_sc_name": "{{(vars.logged_in_user_iri | fromIRI).sourceControlUsername }}"
+                "logged_in_user_sc_name": "{{((vars.currentUser or vars.request['currentUser'] ) | fromIRI).sourceControlUsername}}"
             },
             "status": null,
-            "top": "705",
-            "left": "475",
+            "top": "300",
+            "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "283d973a-f3b8-4b62-aab6-ef2d7e669b70"
@@ -197,8 +131,8 @@
                 "config_id": "None"
             },
             "status": null,
-            "top": "1110",
-            "left": "475",
+            "top": "840",
+            "left": "135",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "83af27eb-b9e4-4338-98f9-a51f700bb19f"
@@ -212,8 +146,8 @@
                 "source_control_username": "{{vars.current_user_source_control_connector_username}}"
             },
             "status": null,
-            "top": "1110",
-            "left": "125",
+            "top": "840",
+            "left": "495",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "38dd5b2a-6b7e-4cf9-b4f4-3ec961cf5b80"
@@ -235,7 +169,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "310",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "6af4157c-8441-423e-8907-09e72fcf7941"
@@ -260,8 +194,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
-            "left": "475",
+            "top": "705",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "5803d81b-20a4-493d-864e-eb45d78c3b13"
@@ -270,53 +204,43 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Get All FSR Users Auth -> Loggedin User Details",
-            "targetStep": "\/api\/3\/workflow_steps\/283d973a-f3b8-4b62-aab6-ef2d7e669b70",
-            "sourceStep": "\/api\/3\/workflow_steps\/b6b0f6c8-0111-4786-9d2b-c9819b5c294a",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "ecc7cd8e-f9c9-4095-baf7-0ae69f0f16a3"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get All FSR Users -> Copy of Get All FSR Users",
-            "targetStep": "\/api\/3\/workflow_steps\/b6b0f6c8-0111-4786-9d2b-c9819b5c294a",
-            "sourceStep": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "3720e697-42a3-4804-9ced-255da5f59e8b"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Current User Configuration -> Return Output",
-            "targetStep": "\/api\/3\/workflow_steps\/38dd5b2a-6b7e-4cf9-b4f4-3ec961cf5b80",
+            "name": "Get Current User Configuration -> Is Connector Configured",
+            "targetStep": "\/api\/3\/workflow_steps\/7b427db2-016f-4c58-af52-b2d259b79426",
             "sourceStep": "\/api\/3\/workflow_steps\/2c4669a5-feca-4025-98f9-190c4ac2020c",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "09364cfb-33e2-4493-95d8-c1426a9063e4"
+            "uuid": "91e6637b-55cf-45bc-bb67-5c7930d10b5d"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Logged User Details -> Is Connector Configure",
-            "targetStep": "\/api\/3\/workflow_steps\/1b057294-590b-4a4d-b951-7b455c52c426",
-            "sourceStep": "\/api\/3\/workflow_steps\/25673a1d-3cc2-4c72-a35b-74fd209f7b1f",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "1d718cc0-b377-48ea-b656-905118614437"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Get Source Control Connector Configurations -> Is FSR Logged in Username Mapped",
-            "targetStep": "\/api\/3\/workflow_steps\/acc75bf1-5995-4f46-91db-151f6cc751ef",
+            "name": "Get Source Control Connector Configurations -> Loggedin User Details",
+            "targetStep": "\/api\/3\/workflow_steps\/283d973a-f3b8-4b62-aab6-ef2d7e669b70",
             "sourceStep": "\/api\/3\/workflow_steps\/d9154b92-9539-49a7-b722-cc6e7ae58174",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "43fe9296-5a2b-440b-977c-1dd13b331a47"
+            "uuid": "114664dd-7768-4d74-a209-f1383d701d53"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Connector Configured -> Return No Output",
+            "targetStep": "\/api\/3\/workflow_steps\/83af27eb-b9e4-4338-98f9-a51f700bb19f",
+            "sourceStep": "\/api\/3\/workflow_steps\/7b427db2-016f-4c58-af52-b2d259b79426",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0721d836-1245-48f2-ac5c-799290453fa8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Connector Configured -> Return Output",
+            "targetStep": "\/api\/3\/workflow_steps\/38dd5b2a-6b7e-4cf9-b4f4-3ec961cf5b80",
+            "sourceStep": "\/api\/3\/workflow_steps\/7b427db2-016f-4c58-af52-b2d259b79426",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b72b4b5d-26d7-4579-a36b-91963aa0a5f2"
         },
         {
             "@type": "WorkflowRoute",
@@ -337,26 +261,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "1304177a-0fcc-40aa-94e3-545acd8dbf16"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is FSR Logged in Username Mapped -> Get All FSR Users",
-            "targetStep": "\/api\/3\/workflow_steps\/b336e79a-0f1c-4c3d-9383-a84ed923299e",
-            "sourceStep": "\/api\/3\/workflow_steps\/acc75bf1-5995-4f46-91db-151f6cc751ef",
-            "label": "No",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "649caaa9-3c07-4687-8022-e44e4ec1506e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Is FSR Logged in Username Mapped -> Get Logged User Details",
-            "targetStep": "\/api\/3\/workflow_steps\/25673a1d-3cc2-4c72-a35b-74fd209f7b1f",
-            "sourceStep": "\/api\/3\/workflow_steps\/acc75bf1-5995-4f46-91db-151f6cc751ef",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "f1143557-7c6e-4622-967b-c79e775d2c07"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
@@ -82,8 +82,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "460",
-            "left": "1220",
+            "top": "340",
+            "left": "1440",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "a23ccc91-bd8e-434a-a9ee-61eeddc4e2cb"
@@ -131,7 +131,7 @@
             },
             "status": null,
             "top": "140",
-            "left": "1000",
+            "left": "1120",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "2c1fa08e-4236-4130-a372-b3452d72ac5a"
@@ -143,23 +143,29 @@
             "arguments": {
                 "conditions": [
                     {
-                        "option": "Pending",
-                        "step_iri": "\/api\/3\/workflow_steps\/3fed066c-a883-49a8-81bc-8be588136f89",
-                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
-                        "step_name": "Update Status as In Progress"
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/536304c2-25ce-41f6-b22f-bead4240417a",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "No Connector Configured"
                     },
                     {
                         "option": "In Progress",
                         "default": true,
                         "step_iri": "\/api\/3\/workflow_steps\/a23ccc91-bd8e-434a-a9ee-61eeddc4e2cb",
                         "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/3fed066c-a883-49a8-81bc-8be588136f89",
+                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
+                        "step_name": "Update Status as In Progress"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
             "top": "260",
-            "left": "1000",
+            "left": "1120",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "845c3ed3-b29d-4af1-8d2f-f9c5e98bcfc0"
@@ -259,6 +265,35 @@
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "2360e578-052b-4f1a-9b3b-d9ccc0999936"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector or User Mapping Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector or is not mapped to a source control username.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "480",
+            "left": "1120",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "536304c2-25ce-41f6-b22f-bead4240417a"
         },
         {
             "@type": "WorkflowStep",
@@ -783,8 +818,8 @@
                 "singleRecordExecution": true
             },
             "status": null,
-            "top": "30",
-            "left": "1000",
+            "top": "20",
+            "left": "1120",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "b4747b90-3981-457f-ae61-6d587bf5129a"
@@ -1026,6 +1061,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "49c009fe-0c6b-4e47-ac2c-99cf34b5e912"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> No Connector Configured",
+            "targetStep": "\/api\/3\/workflow_steps\/536304c2-25ce-41f6-b22f-bead4240417a",
+            "sourceStep": "\/api\/3\/workflow_steps\/845c3ed3-b29d-4af1-8d2f-f9c5e98bcfc0",
+            "label": "Connector Not Config",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "547b04b7-a44c-4873-9932-90a9091608df"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
+++ b/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
@@ -34,30 +34,11 @@
                 "workflowReference": "\/api\/3\/workflows\/fce53c7e-778d-48aa-afb7-8f67830570ab"
             },
             "status": null,
-            "top": "975",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "group": null,
-            "uuid": "c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Source Control Connector Configuration",
-            "description": null,
-            "arguments": {
-                "arguments": [],
-                "apply_async": false,
-                "step_variables": [],
-                "pass_parent_env": false,
-                "pass_input_record": true,
-                "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
-            },
-            "status": null,
-            "top": "435",
+            "top": "1515",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
-            "uuid": "839fafe8-a583-45e0-a7f0-bf5c374a42a7"
+            "uuid": "c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8"
         },
         {
             "@type": "WorkflowStep",
@@ -112,8 +93,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "570",
-            "left": "300",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "cef8c18f-187f-4697-b472-37226b9c1980"
@@ -171,6 +152,21 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Get Current User Configuration",
+            "description": null,
+            "arguments": {
+                "current_user_source_control_connector_username": "{% set ns = namespace(match_found=false, matched_username=None) %}{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.csadmin_user_sc_name.strip() == connector_config.config.username.strip() %}{% set ns.match_found = true %}{% set ns.matched_username = connector_config.config.username %}{% break %}{% endif %}{% endfor %}{% if ns.match_found %}{{ ns.matched_username }}{% else %}null{% endif %}",
+                "current_user_source_control_connector_config_id": "{% set ns = namespace(match_found=false) %}{% for connector_config in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if vars.csadmin_user_sc_name == connector_config.config.username %}{{ connector_config.config_id }}{% set ns.match_found = true %}{% break %}{% endif %}{% endfor %}{% if not ns.match_found %}null{% endif %}"
+            },
+            "status": null,
+            "top": "705",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "c8e82f49-acff-4c3e-860a-2b34eb624f7f"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Get Latest Commit",
             "description": null,
             "arguments": {
@@ -185,11 +181,36 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetCommit\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "705",
-            "left": "300",
+            "top": "1245",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "826926d6-cdb7-4ee8-bdff-5fe1bbe57ad7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Connector Configurations",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/integration\/connectors\/{{vars.cicd_env[\"source_control\"][\"name\"]}}\/{{vars.cicd_env[\"source_control\"][\"version\"]}}\/?format=json",
+                    "body": "",
+                    "method": "POST"
+                },
+                "version": "3.6.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "is_schedule_triggered": "{% if (vars.currentUser == None or vars.request['currentUser'] == None) %}true{% else %}{% if \"\/api\/3\/appliances\/\" in vars.currentUser %}true{% else %}false{% endif %}{% endif %}"
+                }
+            },
+            "status": null,
+            "top": "435",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "ed8558f8-942c-45a2-b856-f246e9e2ca90"
         },
         {
             "@type": "WorkflowStep",
@@ -213,11 +234,53 @@
                 "step_variables": []
             },
             "status": null,
+            "top": "1380",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "2dc6565e-de0b-4331-9d55-12a106ca3793"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Connector Configured",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/b04a493d-98c6-4b57-88c1-008e82603798",
+                        "condition": "{{ vars.current_user_source_control_connector_config_id != None }}",
+                        "step_name": "Source Control Connector Configuration"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/b7c842ce-d37e-42a2-8926-4869ac535f1d",
+                        "step_name": "Return Blank Output"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
             "top": "840",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
-            "uuid": "2dc6565e-de0b-4331-9d55-12a106ca3793"
+            "uuid": "2e502431-6755-48b8-bc9a-87f766b6ea7c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Loggedin User Details",
+            "description": null,
+            "arguments": {
+                "csadmin_user_sc_name": "{{(\"\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce\" | fromIRI).sourceControlUsername }}"
+            },
+            "status": null,
+            "top": "570",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "a6c561ae-d223-4bb9-9cc7-d5f916a721cb"
         },
         {
             "@type": "WorkflowStep",
@@ -232,11 +295,40 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
-            "left": "475",
+            "top": "1515",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "72b152e3-8add-4aab-9454-eb429da57826"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Return Blank Output",
+            "description": null,
+            "arguments": {
+                "exception": "No connector configured for the logged-in user, or CICD is not set up."
+            },
+            "status": null,
+            "top": "975",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "b7c842ce-d37e-42a2-8926-4869ac535f1d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Source Control Connector Configuration",
+            "description": null,
+            "arguments": {
+                "config_id": "{{vars.current_user_source_control_connector_config_id}}",
+                "source_control_username": "{{vars.current_user_source_control_connector_username}}"
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "b04a493d-98c6-4b57-88c1-008e82603798"
         },
         {
             "@type": "WorkflowStep",
@@ -263,23 +355,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Find Last Commit ID",
-            "targetStep": "\/api\/3\/workflow_steps\/cef8c18f-187f-4697-b472-37226b9c1980",
-            "sourceStep": "\/api\/3\/workflow_steps\/839fafe8-a583-45e0-a7f0-bf5c374a42a7",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "cdabf38e-9ccc-4b6c-9b96-c8ac89d08e85"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Configuration -> Check Source Control Connector Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/839fafe8-a583-45e0-a7f0-bf5c374a42a7",
+            "name": "Configuration -> Get Source Control Connector Configurations",
+            "targetStep": "\/api\/3\/workflow_steps\/ed8558f8-942c-45a2-b856-f246e9e2ca90",
             "sourceStep": "\/api\/3\/workflow_steps\/f6b0783b-a048-48d4-ba50-56f2db68674b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "5bed7560-a423-4cd1-b795-277c2f71643a"
+            "uuid": "d8f86d83-b91f-4e89-9c51-a9c407af0ac9"
         },
         {
             "@type": "WorkflowRoute",
@@ -289,7 +371,7 @@
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "6e433a43-3df0-4015-9d13-299952f2cfa5"
+            "uuid": "67d752c1-690c-4375-96fa-cdff51b8aea3"
         },
         {
             "@type": "WorkflowRoute",
@@ -303,6 +385,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Get Current User Configuration -> Is Connector Configured",
+            "targetStep": "\/api\/3\/workflow_steps\/2e502431-6755-48b8-bc9a-87f766b6ea7c",
+            "sourceStep": "\/api\/3\/workflow_steps\/c8e82f49-acff-4c3e-860a-2b34eb624f7f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "44fd5945-f407-4946-a7b6-4c5055eda7bd"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Latest Commit -> Is Commit id Drift",
             "targetStep": "\/api\/3\/workflow_steps\/2dc6565e-de0b-4331-9d55-12a106ca3793",
             "sourceStep": "\/api\/3\/workflow_steps\/826926d6-cdb7-4ee8-bdff-5fe1bbe57ad7",
@@ -310,6 +402,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "c2d7453d-1faf-44a8-a52b-ba26cbc65ce8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Connector Configurations -> Loggedin User Details",
+            "targetStep": "\/api\/3\/workflow_steps\/a6c561ae-d223-4bb9-9cc7-d5f916a721cb",
+            "sourceStep": "\/api\/3\/workflow_steps\/ed8558f8-942c-45a2-b856-f246e9e2ca90",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6d86ff78-80fc-4152-9666-a321852937b0"
         },
         {
             "@type": "WorkflowRoute",
@@ -333,6 +435,46 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Is Connector Configured -> Return Blank Output",
+            "targetStep": "\/api\/3\/workflow_steps\/b7c842ce-d37e-42a2-8926-4869ac535f1d",
+            "sourceStep": "\/api\/3\/workflow_steps\/2e502431-6755-48b8-bc9a-87f766b6ea7c",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1dca8a53-2f7c-4261-85dc-499c39bfe360"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Connector Configured -> Return Output",
+            "targetStep": "\/api\/3\/workflow_steps\/b04a493d-98c6-4b57-88c1-008e82603798",
+            "sourceStep": "\/api\/3\/workflow_steps\/2e502431-6755-48b8-bc9a-87f766b6ea7c",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9122cd68-087e-403d-8165-ded43542ecf2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Loggedin User Details -> Get Current User Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/c8e82f49-acff-4c3e-860a-2b34eb624f7f",
+            "sourceStep": "\/api\/3\/workflow_steps\/a6c561ae-d223-4bb9-9cc7-d5f916a721cb",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "688ddd2c-caa3-47cd-a5d7-4e3373c9b847"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Source Control Connector Configuration -> Find Last Commit ID",
+            "targetStep": "\/api\/3\/workflow_steps\/cef8c18f-187f-4697-b472-37226b9c1980",
+            "sourceStep": "\/api\/3\/workflow_steps\/b04a493d-98c6-4b57-88c1-008e82603798",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0d113bd1-f0d0-44c3-a9a6-b666b02e14fd"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Find Source Control Settings",
             "targetStep": "\/api\/3\/workflow_steps\/815c0c2f-f6fa-46c0-a5ae-15dd8d140b5b",
             "sourceStep": "\/api\/3\/workflow_steps\/668f019d-d72e-4249-8342-c6b671ae1cc6",
@@ -345,7 +487,7 @@
     "groups": [],
     "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "playbookOrigin": "\/api\/3\/picklists\/b6d710a9-a8ec-41ec-8817-fe9fa062fcdd",
-    "isEditable": true,
+    "isEditable": false,
     "uuid": "0d655fb4-fb06-45c7-8b92-3ecb61b1b369",
     "owners": [],
     "isPrivate": false,

--- a/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
+++ b/playbooks/02 - Use Case - CICD/Review and Apply Latest Content.json
@@ -38,8 +38,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "720",
-            "left": "900",
+            "top": "435",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "0154e08c-9c3c-4c7d-9712-adbdc1dcc0a1"
@@ -51,23 +51,29 @@
             "arguments": {
                 "conditions": [
                     {
-                        "option": "Pending",
-                        "step_iri": "\/api\/3\/workflow_steps\/b625b844-8d94-447f-b424-460143465e5f",
-                        "condition": "{{ vars.request.record.status.itemValue == \"Pending\" }}",
-                        "step_name": "Find Source Control Settings"
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/24d8403f-bda8-43cc-b91b-da4e3085311a",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "No Connector Configured"
                     },
                     {
                         "option": "In Progress",
                         "default": true,
                         "step_iri": "\/api\/3\/workflow_steps\/0154e08c-9c3c-4c7d-9712-adbdc1dcc0a1",
                         "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/e412db53-236b-424d-be9d-a4a1f1769295",
+                        "condition": "{{ vars.request.record.status.itemValue == \"Pending\" }}",
+                        "step_name": "Update Status as In Progress"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
-            "left": "650",
+            "top": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "3cc2f63a-5832-4751-a2b1-c99a91d25683"
@@ -85,8 +91,8 @@
                 "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
             },
             "status": null,
-            "top": "300",
-            "left": "650",
+            "top": "165",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "be5a4043-33bf-4678-af22-cf63b82a1747"
@@ -145,6 +151,35 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "b2df08a3-2f4a-4b0a-acd1-ca5f222127c4"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector or User Mapping Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector or is not mapped to a source control username.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.request.record['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "24d8403f-bda8-43cc-b91b-da4e3085311a"
         },
         {
             "@type": "WorkflowStep",
@@ -375,7 +410,7 @@
             },
             "status": null,
             "top": "840",
-            "left": "680",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "476acb98-a2f4-4619-b004-3bf9345afcfa"
@@ -396,7 +431,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e50c86a4-e1de-4bad-8da4-fcf6cb2a9a3e"
@@ -427,8 +462,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "165",
-            "left": "650",
+            "top": "435",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "e412db53-236b-424d-be9d-a4a1f1769295"
@@ -460,8 +495,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "980",
-            "left": "880",
+            "top": "975",
+            "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "dc4eb25a-b075-4417-9a7e-0b00631959a6"
@@ -470,13 +505,23 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Add Comment Playbook Is Active -> Update Status to Pending",
-            "targetStep": "\/api\/3\/workflow_steps\/dc4eb25a-b075-4417-9a7e-0b00631959a6",
-            "sourceStep": "\/api\/3\/workflow_steps\/0154e08c-9c3c-4c7d-9712-adbdc1dcc0a1",
-            "label": null,
+            "name": "Check Record Status -> No Connector Configured",
+            "targetStep": "\/api\/3\/workflow_steps\/24d8403f-bda8-43cc-b91b-da4e3085311a",
+            "sourceStep": "\/api\/3\/workflow_steps\/3cc2f63a-5832-4751-a2b1-c99a91d25683",
+            "label": "Connector Not Config",
             "isExecuted": false,
             "group": null,
-            "uuid": "cc1309f1-fce6-4e5f-9c6a-3bc0055cb69c"
+            "uuid": "5dff3439-6405-4d65-b70a-d84785bac461"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Record Status -> Update Status as In Progress",
+            "targetStep": "\/api\/3\/workflow_steps\/e412db53-236b-424d-be9d-a4a1f1769295",
+            "sourceStep": "\/api\/3\/workflow_steps\/3cc2f63a-5832-4751-a2b1-c99a91d25683",
+            "label": "Pending",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f5a84d08-39e3-4ed0-b990-8da505c703f6"
         },
         {
             "@type": "WorkflowRoute",
@@ -497,16 +542,6 @@
             "isExecuted": false,
             "group": null,
             "uuid": "88cba040-5386-4f75-a8b6-e84139788f28"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Check Status -> Find Source Control Settings",
-            "targetStep": "\/api\/3\/workflow_steps\/b625b844-8d94-447f-b424-460143465e5f",
-            "sourceStep": "\/api\/3\/workflow_steps\/3cc2f63a-5832-4751-a2b1-c99a91d25683",
-            "label": "Pending",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "3ae59eb8-08c0-4435-973d-182606bd3d90"
         },
         {
             "@type": "WorkflowRoute",
@@ -610,23 +645,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Update Status as In Progress",
-            "targetStep": "\/api\/3\/workflow_steps\/e412db53-236b-424d-be9d-a4a1f1769295",
+            "name": "Start -> Check Source Control Connector Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/be5a4043-33bf-4678-af22-cf63b82a1747",
             "sourceStep": "\/api\/3\/workflow_steps\/e50c86a4-e1de-4bad-8da4-fcf6cb2a9a3e",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "caba2b36-5bd2-4c19-8f2d-06c727faedcd"
+            "uuid": "7bab5c0a-8c32-4b32-bd2c-a2466b287141"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Status as In Progress -> Check Source Control Connector Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/be5a4043-33bf-4678-af22-cf63b82a1747",
+            "name": "Update Status as In Progress -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/b625b844-8d94-447f-b424-460143465e5f",
             "sourceStep": "\/api\/3\/workflow_steps\/e412db53-236b-424d-be9d-a4a1f1769295",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "8eceb2cc-0671-49a9-ac4b-3e9375e4dc00"
+            "uuid": "cc852b7d-3ecb-4475-aa08-f13d72e337f1"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Save FortiSOAR Settings.json
+++ b/playbooks/02 - Use Case - CICD/Save FortiSOAR Settings.json
@@ -89,7 +89,7 @@
             },
             "status": null,
             "top": "165",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "e9a925c9-91a9-4ff8-a181-a3817db6e846"
@@ -101,23 +101,29 @@
             "arguments": {
                 "conditions": [
                     {
-                        "option": "Pending",
-                        "step_iri": "\/api\/3\/workflow_steps\/dfc0dbd2-46d2-4e21-8d06-4ab4dcf466fb",
-                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
-                        "step_name": "Update Status In Progress"
-                    },
-                    {
                         "option": "In Progress",
                         "default": true,
                         "step_iri": "\/api\/3\/workflow_steps\/7229addc-ef6a-4bad-9db6-935ecb294616",
                         "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/0c87c283-12ea-4f6c-8c05-5909e7705d16",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "No Connector or CICD Setup"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/dfc0dbd2-46d2-4e21-8d06-4ab4dcf466fb",
+                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
+                        "step_name": "Update Status In Progress"
                     }
                 ],
                 "step_variables": []
             },
             "status": null,
             "top": "300",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "acc9de15-77e7-4cbf-9286-d5837fae7103"
@@ -141,6 +147,35 @@
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "836eadc2-7613-437a-b84e-d1c4c31440dc"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector or User Mapping Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector or is not mapped to a source control username.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "440",
+            "left": "820",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "0c87c283-12ea-4f6c-8c05-5909e7705d16"
         },
         {
             "@type": "WorkflowStep",
@@ -452,7 +487,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "81ba31e6-3c9a-4f87-8cf7-2be72de45b77"
@@ -586,6 +621,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "0154efa4-edaa-4d02-bcdc-4dd8b6843381"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> No Connector or CICD Setup",
+            "targetStep": "\/api\/3\/workflow_steps\/0c87c283-12ea-4f6c-8c05-5909e7705d16",
+            "sourceStep": "\/api\/3\/workflow_steps\/acc9de15-77e7-4cbf-9286-d5837fae7103",
+            "label": "Connector Not Config",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2c9dd47d-574f-4da0-b704-a2a1a8c6ad55"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Set Source Control Username.json
+++ b/playbooks/02 - Use Case - CICD/Set Source Control Username.json
@@ -17,6 +17,35 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Add Comment Playbook Is Active",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Playbook is Active or Awaiting State<\/h5>\n<hr>\n<p>{{vars.input.records[0].title}} operation is in Active\/Awaiting state. Please wait while the previous operation is completed.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "de253445-4cb0-4112-9d53-f398b501c650"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Add Development Collaborator",
             "description": null,
             "arguments": {
@@ -158,7 +187,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -332,7 +361,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "570",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -361,7 +390,7 @@
                 "workflowReference": "\/api\/3\/workflows\/a7087e20-c07a-4f79-80e2-751bd693875f"
             },
             "status": null,
-            "top": "1515",
+            "top": "1650",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -389,7 +418,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "705",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -408,11 +437,45 @@
                 "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
             },
             "status": null,
-            "top": "1380",
-            "left": "125",
+            "top": "165",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "f3dde8a0-dec3-4527-8f7a-2daf1d130806"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "In Progress",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/de253445-4cb0-4112-9d53-f398b501c650",
+                        "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/08c8483c-295c-4193-be9e-aef09171f5aa",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "No Connector or CICD Setup"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/4f4f48ea-abac-4fa2-973f-fcc404229264",
+                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
+                        "step_name": "Set Status to In Progress"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "873a9004-c38c-4c99-ac82-548b27fa7301"
         },
         {
             "@type": "WorkflowStep",
@@ -427,11 +490,40 @@
                 "source_control_username": "{{vars.steps.Add_Development_Collaborator.input.sourceControlUsername or vars.steps.Add_Production_Collaborator.input.sourceControlUsername}}"
             },
             "status": null,
-            "top": "705",
+            "top": "975",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "2bc72d77-98f4-4854-b499-e69997251406"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector or User Mapping Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector or is not mapped to a source control username.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "1000",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "08c8483c-295c-4193-be9e-aef09171f5aa"
         },
         {
             "@type": "WorkflowStep",
@@ -460,7 +552,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
+            "top": "1380",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -493,7 +585,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
+            "top": "1785",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -546,7 +638,7 @@
                 }
             },
             "status": null,
-            "top": "300",
+            "top": "570",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -574,7 +666,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1110",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -628,7 +720,7 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "1785",
+            "top": "1920",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
@@ -660,7 +752,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "165",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -741,7 +833,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "300",
+            "left": "650",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "883f3764-8dbb-46c7-93af-5c6aa6b3a67e"
@@ -773,7 +865,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1515",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -806,7 +898,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1785",
+            "top": "1920",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -829,7 +921,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1245",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -862,7 +954,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1920",
+            "top": "2055",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -922,13 +1014,43 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Add Source Control Repository Collaborator",
-            "targetStep": "\/api\/3\/workflow_steps\/4d15b681-6db0-4c21-8e87-3d079f95a0f6",
+            "name": "Check Source Control Connector Configuration -> Check Status",
+            "targetStep": "\/api\/3\/workflow_steps\/873a9004-c38c-4c99-ac82-548b27fa7301",
             "sourceStep": "\/api\/3\/workflow_steps\/f3dde8a0-dec3-4527-8f7a-2daf1d130806",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "6911da54-b89f-4b57-9cd8-a80d02a9c9db"
+            "uuid": "d871072c-4731-495d-8d2f-d7f6f7aba250"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Add Comment Playbook Is Active",
+            "targetStep": "\/api\/3\/workflow_steps\/de253445-4cb0-4112-9d53-f398b501c650",
+            "sourceStep": "\/api\/3\/workflow_steps\/873a9004-c38c-4c99-ac82-548b27fa7301",
+            "label": "In Progress",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ceb98e04-2553-4936-8461-9e90029e68a7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> No Connector or CICD Setup",
+            "targetStep": "\/api\/3\/workflow_steps\/08c8483c-295c-4193-be9e-aef09171f5aa",
+            "sourceStep": "\/api\/3\/workflow_steps\/873a9004-c38c-4c99-ac82-548b27fa7301",
+            "label": "Connector Not Config",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "84d4ff9a-554b-4cb9-a0c8-cf53b8a1ed36"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Set Status to In Progress",
+            "targetStep": "\/api\/3\/workflow_steps\/4f4f48ea-abac-4fa2-973f-fcc404229264",
+            "sourceStep": "\/api\/3\/workflow_steps\/873a9004-c38c-4c99-ac82-548b27fa7301",
+            "label": "Pending",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "95018c63-9d53-4c4f-99fd-43c16e4c64b9"
         },
         {
             "@type": "WorkflowRoute",
@@ -1018,27 +1140,27 @@
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "19f2d1b1-c874-46f4-b786-963ee32836b8"
+            "uuid": "257593ff-c289-4bcc-a08b-b8e3bea0cd70"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Set Status to In Progress",
-            "targetStep": "\/api\/3\/workflow_steps\/4f4f48ea-abac-4fa2-973f-fcc404229264",
+            "name": "Start -> Check Source Control Connector Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/f3dde8a0-dec3-4527-8f7a-2daf1d130806",
             "sourceStep": "\/api\/3\/workflow_steps\/883f3764-8dbb-46c7-93af-5c6aa6b3a67e",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "fd1ebf92-1062-4493-bb67-48bff0ef70d4"
+            "uuid": "46d8e6a8-aaa4-4680-9993-bca52d387033"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Record -> Check Source Control Connector Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/f3dde8a0-dec3-4527-8f7a-2daf1d130806",
+            "name": "Update Record -> Add Source Control Repository Collaborator",
+            "targetStep": "\/api\/3\/workflow_steps\/4d15b681-6db0-4c21-8e87-3d079f95a0f6",
             "sourceStep": "\/api\/3\/workflow_steps\/0d76fae3-42c2-4c0f-8315-4d6eb62ab73a",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "144417f6-1152-457a-a3d4-f8be2d8b8152"
+            "uuid": "886495cb-0c10-461b-8600-639367e4c7bb"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Setup Development Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup Development Environment.json
@@ -17,6 +17,35 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Add Comment Playbook Is Active",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Playbook is Active or Awaiting State<\/h5>\n<hr>\n<p>{{vars.input.records[0].title}} operation is in Active\/Awaiting state. Please wait while the previous operation is completed.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "ae79dbf7-6f79-4a42-93c5-f11c05a96fdd"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Check Source Control Connector Configuration",
             "description": null,
             "arguments": {
@@ -29,10 +58,44 @@
             },
             "status": null,
             "top": "705",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "ff9d7102-e5eb-422f-a0fd-f1fde6ce92a1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/f705f00a-25d9-4560-9c37-4884718b965c",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "Connector or User Mapping Missing"
+                    },
+                    {
+                        "option": "In Progress",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/ae79dbf7-6f79-4a42-93c5-f11c05a96fdd",
+                        "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/3e498601-2199-4e52-a2b6-ff42943f76da",
+                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
+                        "step_name": "Get Source Control Server URL"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "a9602450-1bb3-4e24-8577-5b964c81d914"
         },
         {
             "@type": "WorkflowStep",
@@ -50,7 +113,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"CloneRepository\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "2055",
+            "top": "2190",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -65,10 +128,39 @@
             },
             "status": null,
             "top": "165",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "8c92404f-c1d4-4491-9901-6d539f85a60d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector Configuration Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "f705f00a-25d9-4560-9c37-4884718b965c"
         },
         {
             "@type": "WorkflowStep",
@@ -89,8 +181,8 @@
                 }
             },
             "status": null,
-            "top": "1515",
-            "left": "218",
+            "top": "1660",
+            "left": "340",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "99743434-451f-4875-80a0-97015a247b59"
@@ -122,7 +214,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2460",
+            "top": "2595",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
@@ -168,7 +260,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "d6361533-2559-4343-bb71-7fce9c195643"
@@ -181,7 +273,7 @@
                 "cicd_env": "{% set cicdEnv = (globalVars.cicd_env | toDict) %}{% set _ = cicdEnv.source_control.update({\"baseURL\": vars.steps.Get_Source_Control_Server_URL.data['server_url'] | trim(\"\/\")}) %}{{cicdEnv}}"
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -293,8 +385,8 @@
                 "external_email_attachments": null
             },
             "status": null,
-            "top": "1380",
-            "left": "218",
+            "top": "1520",
+            "left": "340",
             "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
             "group": null,
             "uuid": "908ec37d-cb1f-4c45-955a-11324893b0d3"
@@ -314,7 +406,7 @@
                 "workflowReference": "{{(globalVars.cicd_env | toDict)[\"source_control_playbooks\"][\"GetServerURL\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -342,7 +434,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1380",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -366,7 +458,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2190",
+            "top": "2325",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
@@ -385,7 +477,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "c743714d-a718-4aef-9e2e-f98d86501c21"
@@ -401,7 +493,7 @@
                 "dev_settings_repo": "{{vars.cicd_config.devSettingsRepoName or vars.steps.Get_Repositories_Details.input.developmentSettingsRepositoryName}}"
             },
             "status": null,
-            "top": "1785",
+            "top": "1920",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -431,7 +523,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2595",
+            "top": "2730",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -456,7 +548,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2325",
+            "top": "2460",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -489,10 +581,34 @@
             },
             "status": null,
             "top": "300",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "34b7c5f5-4bae-4625-b626-cd8bed4060d8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Status Pending",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1110",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "e0beed5b-076b-459c-8bc3-d222ee5b4549"
         },
         {
             "@type": "WorkflowStep",
@@ -553,7 +669,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "ac61e885-f89b-4ca1-9484-ae4e32fd3b76"
@@ -574,7 +690,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
+            "top": "1245",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -607,7 +723,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1920",
+            "top": "2055",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -637,8 +753,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
-            "left": "218",
+            "top": "1780",
+            "left": "340",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a30e093b-ac0a-4a95-9e17-2141c7fd8037"
@@ -669,7 +785,7 @@
                 }
             },
             "status": null,
-            "top": "2730",
+            "top": "2865",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
@@ -679,13 +795,43 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Get Source Control Server URL",
-            "targetStep": "\/api\/3\/workflow_steps\/3e498601-2199-4e52-a2b6-ff42943f76da",
+            "name": "Check Source Control Connector Configuration -> Check Status",
+            "targetStep": "\/api\/3\/workflow_steps\/a9602450-1bb3-4e24-8577-5b964c81d914",
             "sourceStep": "\/api\/3\/workflow_steps\/ff9d7102-e5eb-422f-a0fd-f1fde6ce92a1",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "70e9a20f-efb6-4b2f-b193-beb9cea43af1"
+            "uuid": "16439dbc-09b6-4391-bfee-7fad77219880"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Add Comment Playbook Is Active",
+            "targetStep": "\/api\/3\/workflow_steps\/ae79dbf7-6f79-4a42-93c5-f11c05a96fdd",
+            "sourceStep": "\/api\/3\/workflow_steps\/a9602450-1bb3-4e24-8577-5b964c81d914",
+            "label": "In Progress",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0063f2f8-71ac-488f-b30b-3c8ebbcaab5c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Connector or User Mapping Missing",
+            "targetStep": "\/api\/3\/workflow_steps\/f705f00a-25d9-4560-9c37-4884718b965c",
+            "sourceStep": "\/api\/3\/workflow_steps\/a9602450-1bb3-4e24-8577-5b964c81d914",
+            "label": "Connector Not Config",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ceeee518-f343-4440-8c09-cede65c9532c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Get Source Control Server URL",
+            "targetStep": "\/api\/3\/workflow_steps\/3e498601-2199-4e52-a2b6-ff42943f76da",
+            "sourceStep": "\/api\/3\/workflow_steps\/a9602450-1bb3-4e24-8577-5b964c81d914",
+            "label": "Pending",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b3701233-020d-4a19-827f-f4ebdbe6509f"
         },
         {
             "@type": "WorkflowRoute",
@@ -706,6 +852,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "e4143d74-77e8-41b3-84f1-cc65411a0ef7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Connector or User Mapping Missing -> Set Status Pending",
+            "targetStep": "\/api\/3\/workflow_steps\/e0beed5b-076b-459c-8bc3-d222ee5b4549",
+            "sourceStep": "\/api\/3\/workflow_steps\/f705f00a-25d9-4560-9c37-4884718b965c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9cabb0c2-c6f7-42e8-ab61-f4df9c0c2479"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Setup Production Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup Production Environment.json
@@ -17,6 +17,35 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Add Comment Playbook Is Active",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Playbook is Active or Awaiting State<\/h5>\n<hr>\n<p>{{vars.input.records[0].title}} operation is in Active\/Awaiting state. Please wait while the previous operation is completed.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "560",
+            "left": "980",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "29045bf0-e1d4-4e09-a8b6-81ed2219d475"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Are Repo Created Manually",
             "description": null,
             "arguments": {
@@ -89,11 +118,74 @@
                 "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
             },
             "status": null,
-            "top": "435",
-            "left": "300",
+            "top": "380",
+            "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "b60fae65-d8fb-4bc7-9798-92a9be3dcfb1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Status",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Connector Not Config",
+                        "step_iri": "\/api\/3\/workflow_steps\/31be23f6-9b8f-477a-a737-d21f20361c75",
+                        "condition": "{{ vars.steps.Check_Source_Control_Connector_Configuration.config_id == None }}",
+                        "step_name": "Connector or User Mapping Missing"
+                    },
+                    {
+                        "option": "In Progress",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/29045bf0-e1d4-4e09-a8b6-81ed2219d475",
+                        "step_name": "Add Comment Playbook Is Active"
+                    },
+                    {
+                        "option": "Pending",
+                        "step_iri": "\/api\/3\/workflow_steps\/0e7a9129-086a-4266-967f-29e4a54f1851",
+                        "condition": "{{ vars.input.records[0].status.itemValue == \"Pending\" }}",
+                        "step_name": "Get Source Control Server URL"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "500",
+            "left": "660",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "0de730c8-e7fd-41b6-96a8-5b353bdeb79d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Connector or User Mapping Missing",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "people": [],
+                    "content": "<h5>Warning: Connector Configuration Missing<\/h5>\n<hr>\n<p>The logged-in user does not have a configured source control connector.<\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false,
+                    "changeManagement": "{{vars.input.records[0]['@id']}}"
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "700",
+            "left": "660",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "31be23f6-9b8f-477a-a737-d21f20361c75"
         },
         {
             "@type": "WorkflowStep",
@@ -286,8 +378,8 @@
                 "workflowReference": "\/api\/3\/workflows\/d539f6cc-69ca-44ec-a622-e233aa51970a"
             },
             "status": null,
-            "top": "300",
-            "left": "300",
+            "top": "260",
+            "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
             "uuid": "5b1f5049-732b-4894-8542-369ede0ab465"
@@ -523,8 +615,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "165",
-            "left": "300",
+            "top": "140",
+            "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "52ca8e42-4704-4b06-8901-63c083cfc007"
@@ -550,6 +642,30 @@
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "9226fc8e-7de0-40b6-9f6f-fe8860f58a8e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Set Status Pending",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
+                },
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "660",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "6990ca7c-cbc2-412f-b2d6-3a85c5179d3d"
         },
         {
             "@type": "WorkflowStep",
@@ -642,8 +758,8 @@
                 "singleRecordExecution": true
             },
             "status": null,
-            "top": "30",
-            "left": "300",
+            "top": "20",
+            "left": "660",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
             "uuid": "4b469313-7f5e-4829-be90-820574f2b016"
@@ -714,13 +830,53 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Get Source Control Server URL",
-            "targetStep": "\/api\/3\/workflow_steps\/0e7a9129-086a-4266-967f-29e4a54f1851",
+            "name": "Check Source Control Connector Configuration -> Check Status",
+            "targetStep": "\/api\/3\/workflow_steps\/0de730c8-e7fd-41b6-96a8-5b353bdeb79d",
             "sourceStep": "\/api\/3\/workflow_steps\/b60fae65-d8fb-4bc7-9798-92a9be3dcfb1",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e70229e5-b2a0-4506-ad7c-449499ddda5e"
+            "uuid": "43a78276-5ca5-4005-a113-ca83b643235d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Add Comment Playbook Is Active",
+            "targetStep": "\/api\/3\/workflow_steps\/29045bf0-e1d4-4e09-a8b6-81ed2219d475",
+            "sourceStep": "\/api\/3\/workflow_steps\/0de730c8-e7fd-41b6-96a8-5b353bdeb79d",
+            "label": "In Progress",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d27719d1-5938-4d6c-804e-60fd1c57931f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Connector or User Mapping Missing",
+            "targetStep": "\/api\/3\/workflow_steps\/31be23f6-9b8f-477a-a737-d21f20361c75",
+            "sourceStep": "\/api\/3\/workflow_steps\/0de730c8-e7fd-41b6-96a8-5b353bdeb79d",
+            "label": "Connector Not Config",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0ed8d6be-de3a-406a-a14d-6b44bba756f0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Status -> Get Source Control Server URL",
+            "targetStep": "\/api\/3\/workflow_steps\/0e7a9129-086a-4266-967f-29e4a54f1851",
+            "sourceStep": "\/api\/3\/workflow_steps\/0de730c8-e7fd-41b6-96a8-5b353bdeb79d",
+            "label": "Pending",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7f70b8df-e550-4929-9de7-ce1866ce7502"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Connector or User Mapping Missing -> Set Status Completed",
+            "targetStep": "\/api\/3\/workflow_steps\/6990ca7c-cbc2-412f-b2d6-3a85c5179d3d",
+            "sourceStep": "\/api\/3\/workflow_steps\/31be23f6-9b8f-477a-a737-d21f20361c75",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0c90f549-075a-4356-9db2-c111e74b7fb3"
         },
         {
             "@type": "WorkflowRoute",


### PR DESCRIPTION
---

#### 1205151 | "Fetch Open Requests (Issues)" playbook fails if FortiSOAR user is mapped to source control, but connector is not configured

- Updated `Get Source Control Connector Configuration` playbook:
  - Removed unnecessary steps:
    - Get All FSR Users
    - Is FSR Logged in Username Mapped
    - Get All FSR Users Auth
  - Modified Jinja expressions in **“Get Current User Configuration”** step:
    - `current_user_source_control_connector_username`
    - `current_user_source_control_connector_config_id`
  - Removed `is_schedule_triggered` variable from **“Get Source Control Connector Configurations”** step
  - Updated the condition in **“Is Connector Configured”** step

---

#### 1104990 | Issue with Multiple Prod Environment Setup

- Updated `Create Release` playbook:
  - In the **“Configuration”** step, updated `release_number` value from `"1.0"` to `"1.0.0"`

---

#### 1205148, 1203406 | "Retrieve Source Control Sync Status" playbook issues

- Updated `Retrieve Source Control Sync Status` playbook:
  - Now uses `csadmin` user's source control username consistently
  - This playbook runs on a schedule and requires `source-control-username`
  - **Documentation Impact**: Ensure `csadmin` is always mapped and has a configured source control connector

---

#### 1207758 | Connector or User Mapping Missing

- **RCA**: The following playbooks were executed even when connector or user mapping was missing for the logged-in user:
  - Pull Latest Content from Source Control
  - Review and Apply Latest Content
  - Save FortiSOAR Settings
  - Set Source Control Username
  - Setup Development Environment
  - Setup Production Environment
  - Fetch Closed Requests (Issues)

---

#### 1207760 | Enhance "Get Source Control Connector Configuration" playbook

- Removed unnecessary steps:
  - Get All FSR Users
  - Is FSR Logged in Username Mapped
  - Get All FSR Users Auth
- Modified Jinja expressions in **“Get Current User Configuration”** step:
  - `current_user_source_control_connector_username`
  - `current_user_source_control_connector_config_id`
- Removed `is_schedule_triggered` variable
- Updated the condition in **“Is Connector Configured”** step

---

#### — | Updated "Create a Request (Issue)" playbook

- Updated the **“Raise Exception”** message to:

  ```
  The logged-in user does not have a configured source control connector or is not mapped to a source control username.
  ```

---
