### PR TITLE
CICD upgrade script

### DIFF
--- a/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
@@ -1,4 +1,5 @@
 {
+    "@context": "\/api\/3\/contexts\/Workflow",
     "@type": "Workflow",
     "triggerLimit": null,
     "name": "Setup CICD Environment",
@@ -34,8 +35,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1520",
-            "left": "480",
+            "top": "1650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "7654b64e-acba-4cd9-a17f-5d473404c784"
@@ -68,8 +69,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "700",
-            "left": "480",
+            "top": "840",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "7aeabc30-3990-4b2f-933c-ca56a2c29028"
@@ -79,13 +80,13 @@
             "name": "Configuration",
             "description": null,
             "arguments": {
-                "cicd_config": "{% set env = [] %}{% for item in vars.request.selectedEnv.picklist %}{% set _ = env.append({\"itemValue\": item.itemValue, \"@id\": item[\"@id\"]}) %}{% endfor %}{\"env_config\": {{env}}, \"source_control\": {{vars.request.sourceControl}}}",
+                "cicd_config": "{% set env = [] %}{% for item in vars.request.selectedEnv.picklist %}{% set _ = env.append({\"itemValue\": item.itemValue, \"@id\": item[\"@id\"]}) %}{% endfor %}{\"env_config\": {{env}}, \"source_control\": {{vars.updated_source_control}} }",
                 "setup_record_list": "[\"Setup the Source Control for Production Environment\", \"Setup the Development Environment\"]",
                 "source_control_operations": "{% set filtered = [] %}{% for item in ((vars.steps.Get_Source_Control_Playbooks.data['hydra:member'] | json_query(\"[?isActive==`true`].recordTags\")) | flatten(levels=1)) %}{% if '-' in item %}{% do filtered.append(item) %}{% endif %}{% endfor %}{{filtered}}"
             },
             "status": null,
-            "top": "440",
-            "left": "480",
+            "top": "570",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "72d4a7bd-82d9-45ce-8092-de138c20189b"
@@ -106,8 +107,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1240",
-            "left": "480",
+            "top": "1380",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "813442f4-8ab0-4a86-9af4-515fb8dc8985"
@@ -135,11 +136,35 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "580",
-            "left": "480",
+            "top": "705",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "0aded246-f9d5-48f2-829c-37952fe60070"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Connector",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "query": "{{\n{\n    \"__selectFields\": [\"name\", \"label\", \"version\", \"uuid\"],\n    \"logic\": \"AND\",\n    \"filters\": [\n        {\n            \"field\": \"type\",\n            \"operator\": \"in\",\n            \"value\": [\n                \"connector\"\n            ]\n        },\n       {\n            \"field\": \"installed\",\n            \"operator\": \"eq\",\n            \"value\": true\n        },\n        {\n            \"field\": \"name\",\n            \"operator\": \"eq\",\n            \"value\" : vars.request.sourceControl.name\n        }\n    ]\n}\n}}",
+                    "resource": "solutionpacks"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "query_cyops_resource",
+                "operationTitle": "FSR: Find Record",
+                "step_variables": {
+                    "updated_source_control": "{% set updated_source_control = {} %}{% for k, v in vars.steps.Get_Source_Control_Connector.data[0].items() %}{% if not k.startswith('@') %}{% set _ = updated_source_control.update({k: v}) %}{% endif %}{% endfor %}{% set _ = updated_source_control.update({\"baseURL\":vars.request.sourceControl.baseURL}) %}{{updated_source_control}}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "d1eaca9b-1b7e-4a71-8678-a9a970cd1260"
         },
         {
             "@type": "WorkflowStep",
@@ -147,7 +172,7 @@
             "description": null,
             "arguments": {
                 "params": {
-                    "iri": "\/api\/3\/workflow_collections?$limit=2147483647&$orderby=name&$relationships=true&__selectFields=fsr_primary,workflowCount&name=Sample - {{vars.request.sourceControl.label}} - {{vars.request.sourceControl.version}}",
+                    "iri": "\/api\/3\/workflow_collections?$limit=2147483647&$orderby=name&$relationships=true&__selectFields=fsr_primary,workflowCount&name=Sample - {{vars.steps.Get_Source_Control_Connector.data[0].label}} - {{vars.steps.Get_Source_Control_Connector.data[0].version}}",
                     "body": "",
                     "method": "GET"
                 },
@@ -158,8 +183,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "160",
-            "left": "480",
+            "top": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "fc39f306-f324-47bc-a307-3d0bb2a2bbee"
@@ -181,8 +206,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
-            "left": "480",
+            "top": "435",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "d5836224-b1bc-485b-b5d8-4f251df39d05"
@@ -204,8 +229,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "480",
+            "top": "1515",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "71c4410e-c4d8-47b2-8387-775da6d096bc"
@@ -233,8 +258,8 @@
                 }
             },
             "status": null,
-            "top": "1100",
-            "left": "480",
+            "top": "1245",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "b688e2d8-9214-4196-9952-5f623d8637eb"
@@ -268,8 +293,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "140",
+            "top": "975",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "09e37b88-4466-4104-87c4-a4c8b3640696"
@@ -303,8 +328,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "920",
-            "left": "480",
+            "top": "1110",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "990eb8db-3c12-4144-bcda-9ba15717e849"
@@ -338,7 +363,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -356,8 +381,8 @@
                 }
             },
             "status": null,
-            "top": "40",
-            "left": "480",
+            "top": "30",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e3243c1a-daf7-4bf1-901a-8cc380e797f2"
@@ -388,8 +413,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "980",
-            "left": "140",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a84c99ad-f48e-405d-a1df-4100fc01f7a3"
@@ -420,7 +445,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -500,6 +525,16 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Get Source Control Connector -> Get Source Control Playbook Collection",
+            "targetStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
+            "sourceStep": "\/api\/3\/workflow_steps\/d1eaca9b-1b7e-4a71-8678-a9a970cd1260",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0b505797-b065-4610-965b-242c5181ef94"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Get Source Control Playbook Collection -> Get Source Control Playbooks",
             "targetStep": "\/api\/3\/workflow_steps\/d5836224-b1bc-485b-b5d8-4f251df39d05",
             "sourceStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
@@ -560,13 +595,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get Source Control Playbook Collection",
-            "targetStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
+            "name": "Start -> Get Source Control Connector",
+            "targetStep": "\/api\/3\/workflow_steps\/d1eaca9b-1b7e-4a71-8678-a9a970cd1260",
             "sourceStep": "\/api\/3\/workflow_steps\/e3243c1a-daf7-4bf1-901a-8cc380e797f2",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "02911476-6c4c-4a4e-895b-e8fd33fcf8aa"
+            "uuid": "a4104760-bec6-405b-9d54-f815806aaf0e"
         },
         {
             "@type": "WorkflowRoute",

--- a/postInstall/execution_list.json
+++ b/postInstall/execution_list.json
@@ -1,0 +1,3 @@
+{
+    "execution_sequence":["83cfe2a7-5149-4b5e-906d-64310f33b8e7"]
+}

--- a/postInstall/workflow/CICD Upgrade Script.json
+++ b/postInstall/workflow/CICD Upgrade Script.json
@@ -1,0 +1,979 @@
+{
+    "@context": "\/api\/3\/contexts\/Workflow",
+    "@type": "Workflow",
+    "triggerLimit": null,
+    "name": "CICD Upgrade Script",
+    "aliasName": null,
+    "tag": null,
+    "description": "Configure the CICD v3.1.0 settings after system upgrade.",
+    "isActive": true,
+    "debug": false,
+    "singleRecordExecution": false,
+    "remoteExecutableFlag": false,
+    "parameters": [],
+    "synchronous": false,
+    "collection": "\/api\/3\/workflow_collections\/d4665980-9836-4181-9dc1-84dc61bfc696",
+    "versions": [],
+    "triggerStep": "\/api\/3\/workflow_steps\/0af508fb-a31f-4a3d-9e9d-e60986a02f77",
+    "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Setup Type",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Prod,Dev",
+                        "step_iri": "\/api\/3\/workflow_steps\/e7dd7c3b-9c7c-45f2-a1b4-80f80916b10e",
+                        "condition": "{{ vars.steps.Get_Key_Store_Record[0].value == \"Development,Production\" }}",
+                        "step_name": "Update Both Prod Environment"
+                    },
+                    {
+                        "option": "Prod",
+                        "step_iri": "\/api\/3\/workflow_steps\/63c46ec5-30e3-4cd5-8202-3d51935ccfcd",
+                        "condition": "{{ vars.steps.Get_Key_Store_Record[0].value == \"Production\" }}",
+                        "step_name": "Update Prod Environment"
+                    },
+                    {
+                        "option": "Dev",
+                        "step_iri": "\/api\/3\/workflow_steps\/a055452e-e454-4d5d-8cf4-00554045dfa8",
+                        "condition": "{{ vars.steps.Get_Key_Store_Record[0].value == \"Development\" }}",
+                        "step_name": "Update Dev Environment"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "aeb19201-0669-4865-b146-997d2a252b8d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Check Source Control Connector Configuration",
+            "description": null,
+            "arguments": {
+                "arguments": [],
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": true,
+                "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
+            },
+            "status": null,
+            "top": "705",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "dd1ad8e0-ad8b-4272-9e4b-6c7d4acae82a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Delete CICD Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/{{vars.cicd_config_gv_id}}\/?format=json",
+                    "body": "",
+                    "method": "DELETE"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "ignore_errors": true,
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "8d0d1e36-61e8-498a-a83e-dcc8ba5ed71f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Environment Type",
+            "description": null,
+            "arguments": {
+                "env_type": "{% if ',' in vars.steps.Get_Key_Store_Record[0].value %}{{\"Change Management Environment\" | picklist(\"Production\", \"@id\")}}{% else %}{{\"Change Management Environment\" | picklist(vars.steps.Get_Key_Store_Record[0].value, \"@id\")}}{% endif %}"
+            },
+            "status": null,
+            "top": "1245",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "38b861cb-bf5b-410b-b3ab-2a5a9cfa531f"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find CICD Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?offset=0&limit=2147483647",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "ignore_errors": false,
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "cicd_config_gv_id": "{{((vars.steps.Find_CICD_Global_Variable.data[\"hydra:member\"] | json_query(\"[?name=='cicd_config'].id\"))[0] | string) }}"
+                }
+            },
+            "status": null,
+            "top": "1650",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "9782af0e-07ee-4212-ab68-1b693d94ae65"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Setup Environments",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "{{vars.setup_records}}",
+                            "operator": "in",
+                            "_operator": "in"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1110",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "19684900-c7eb-4486-a95c-7db378305209"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Find Source Control Setting Record",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "Source Control Settings",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        },
+                        {
+                            "type": "object",
+                            "field": "environment",
+                            "value": "{{vars.env_type}}",
+                            "_value": {
+                                "@id": "{{vars.env_type}}",
+                                "display": "",
+                                "itemValue": ""
+                            },
+                            "operator": "eq"
+                        }
+                    ]
+                },
+                "module": "change_management?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1380",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "00b7753a-2a8a-4a26-a523-d6cf755da653"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get CICD Config Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/wf\/api\/dynamic-variable\/?offset=0&limit=2147483647&name=cicd_config",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "1a140d91-aba9-4d17-9303-e26f91efedb1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Key Store Record",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "key",
+                            "value": "CICD FortiSOAR Environment",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ]
+                },
+                "module": "keys?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "e760d2ad-13c7-4f96-a2eb-a8aa89a9f1f9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Connector",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "query": "{{\n{\n    \"__selectFields\": [\"name\", \"label\", \"version\", \"uuid\"],\n    \"logic\": \"AND\",\n    \"filters\": [\n        {\n            \"field\": \"type\",\n            \"operator\": \"in\",\n            \"value\": [\n                \"connector\"\n            ]\n        },\n       {\n            \"field\": \"installed\",\n            \"operator\": \"eq\",\n            \"value\": true\n        },\n        {\n            \"field\": \"name\",\n            \"operator\": \"in\",\n            \"value\" : vars.cicd_env.source_control.name\n        }\n    ]\n}\n}}",
+                    "resource": "solutionpacks"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "query_cyops_resource",
+                "operationTitle": "FSR: Find Record",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1785",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "765ad568-c4e7-4d73-b6b9-1bc04113b2a8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Server URL",
+            "description": null,
+            "arguments": {
+                "arguments": {
+                    "connector_config_id": "{{vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}"
+                },
+                "apply_async": false,
+                "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": true,
+                "workflowReference": "{{vars.steps.Get_Workflow_IRI.data[\"hydra:member\"][0][\"@id\"]}}"
+            },
+            "status": null,
+            "top": "975",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "928eab73-30b8-47c4-8038-dab7cab8a416"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Update CICD Env Global Variable",
+            "description": null,
+            "arguments": {
+                "updated_cicd_env": "{% set cleaned_source_control = {} %}{% for key, value in vars.steps.Get_Source_Control_Connector.data[0].items() %}{% if key != '@id' and key != '@type' %}{% set _ = cleaned_source_control.update({key: value}) %}{% endif %}\n{% endfor %}{% set _ = cleaned_source_control.update({\"baseURL\": vars.steps.Get_Source_Control_Server_URL.data['server_url'] | trim(\"\/\") }) %}{% set cicd_env = vars.cicd_env %}{% set _ = cicd_env.update({\"source_control\": cleaned_source_control }) %}{{ cicd_env }}"
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "47c8c19b-1d7b-46d2-b372-ec5326988a92"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Workflow IRI",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/3\/workflows?$limit=30&$orderby=-modifyDate&name={{vars.cicd_env.source_control_playbooks.GetServerURL.name | urlencode}}",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "server_url_pb_iri": "{{vars.steps.Get_Workflow_IRI.data[\"hydra:member\"][0][\"@id\"]}}"
+                }
+            },
+            "status": null,
+            "top": "840",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "90d93b94-70dc-4d3e-8527-6e292bf92f81"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Upgrade",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/1a140d91-aba9-4d17-9303-e26f91efedb1",
+                        "condition": "{{ vars.steps.Get_Key_Store_Record | length > 0 }}",
+                        "step_name": "Get CICD Config Global Variable"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/8995caa1-2b81-4866-810d-11078ffcc626",
+                        "step_name": "No Operation"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "9d19fb34-9891-4a50-8bbf-a1a25924c2df"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Map CICD Configuration",
+            "description": null,
+            "arguments": {
+                "source_control_config": "{\n\"baseBranch\": \"{{vars.cicd_config.baseBranch}}\",\n\"contentRepoName\": \"{{vars.cicd_config.contentRepoName}}\",\n\"organizationName\": \"{{vars.cicd_config.organizationName}}\",\n\"source_control_url\": \"{{vars.steps.Get_Source_Control_Server_URL.data['server_url'] | trim(\"\/\")}}\",\n\"devSettingsRepoName\": \"{{vars.cicd_config.devSettingsRepoName}}\",\n\"prodSettingsRepoName\": \"{{vars.cicd_config.prodSettingsRepoName}}\",\n}"
+            },
+            "status": null,
+            "top": "1110",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "1843b9f1-f61d-4ad5-a576-c13662ff1352"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "No Operation",
+            "description": null,
+            "arguments": {
+                "params": [],
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "no_op",
+                "operationTitle": "Utils: No Operation",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "8995caa1-2b81-4866-810d-11078ffcc626"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Refine CICD Config Global Variable",
+            "description": null,
+            "arguments": {
+                "cicd_env": "{{globalVars.cicd_env}}",
+                "cicd_config": "{{vars.steps.Get_CICD_Config_Global_Variable.data['hydra:member'][0].value}}",
+                "setup_records": "[\"Setup the Development Environment\", \"Setup the Source Control for Production Environment\"]"
+            },
+            "status": null,
+            "top": "570",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "1bbf31ac-471e-49a9-9e7c-7b6aaf65a314"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Start",
+            "description": null,
+            "arguments": {
+                "__triggerLimit": true,
+                "step_variables": {
+                    "input": {
+                        "params": []
+                    }
+                },
+                "triggerOnSource": true,
+                "triggerOnReplicate": false
+            },
+            "status": null,
+            "top": "30",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+            "group": null,
+            "uuid": "0af508fb-a31f-4a3d-9e9d-e60986a02f77"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Both Dev Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Development Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "{{null}}",
+                    "status": "{% if (vars.steps.Find_Setup_Environments | json_query(\"[?title == 'Setup the Source Control for Production Environment'].status.itemValue\"))[0] == \"Completed\" %}{{\"Change Management Status\" | picklist(\"Completed\", \"@id\")}}{% endif %}",
+                    "environment": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1515",
+            "left": "1175",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "c702091d-605a-445a-90be-e34f25fb5387"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Both Prod Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Source Control for Production Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                    "environment": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1380",
+            "left": "1175",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "e7dd7c3b-9c7c-45f2-a1b4-80f80916b10e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update CICD Config Settings",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "configurationParameters": "{{vars.source_control_config}}"
+                },
+                "operation": "Append",
+                "collection": "{{vars.steps.Find_Source_Control_Setting_Record[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1515",
+            "left": "125",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "950dc53c-5846-4e1e-b965-b9ffc089dd01"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update CICD Env Global Variable",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "macro": "cicd_env",
+                    "value": "{{vars.updated_cicd_env | toJSON}}"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "updatemacro",
+                "operationTitle": "FSR: Create\/Update Global Variables",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2055",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "1a32eb89-15c9-4e73-adde-8bcd0969ae3b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Dev Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Development Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                    "environment": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1380",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "a055452e-e454-4d5d-8cf4-00554045dfa8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Dev Prod Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Source Control for Production Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "{{null}}",
+                    "status": "{% if (vars.steps.Find_Setup_Environments | json_query(\"[?title == 'Setup the Development Environment'].status.itemValue\"))[0] == \"Completed\" %}{{\"Change Management Status\" | picklist(\"Pending\", \"@id\")}}{% endif %}",
+                    "environment": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1515",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "17f8bff1-ac4d-4e8f-9803-9ef28aedc1b8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Prod Dev Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Development Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "{{null}}",
+                    "status": "{% if (vars.steps.Find_Setup_Environments | json_query(\"[?title == 'Setup the Source Control for Production Environment'].status.itemValue\"))[0] == \"Completed\" %}{{\"Change Management Status\" | picklist(\"Pending\", \"@id\")}}{% endif %}",
+                    "environment": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1515",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "f4466f30-3cde-4896-b31b-577cc41cc688"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Prod Environment",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.steps.Find_Setup_Environments}}",
+                    "__bulk": true,
+                    "parallel": false,
+                    "condition": "{{vars.item.title == \"Setup the Source Control for Production Environment\"}}",
+                    "batch_size": 100
+                },
+                "resource": {
+                    "type": "\/api\/3\/picklists\/b43deb65-1edc-482b-b20e-1fed06bbc01c",
+                    "environment": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.item['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1380",
+            "left": "825",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "63c46ec5-30e3-4cd5-8202-3d51935ccfcd"
+        }
+    ],
+    "routes": [
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Setup Type -> Update Dev Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/a055452e-e454-4d5d-8cf4-00554045dfa8",
+            "sourceStep": "\/api\/3\/workflow_steps\/aeb19201-0669-4865-b146-997d2a252b8d",
+            "label": "Dev",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ff7f3e63-7f68-4d91-bfde-3e72760eb4d8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Setup Type -> Update Prod Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/63c46ec5-30e3-4cd5-8202-3d51935ccfcd",
+            "sourceStep": "\/api\/3\/workflow_steps\/aeb19201-0669-4865-b146-997d2a252b8d",
+            "label": "Prod",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e43dbe58-4d65-4826-812e-191f20f92fa9"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Setup Type -> Update Production Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/e7dd7c3b-9c7c-45f2-a1b4-80f80916b10e",
+            "sourceStep": "\/api\/3\/workflow_steps\/aeb19201-0669-4865-b146-997d2a252b8d",
+            "label": "Prod,Dev",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6460a984-f6c8-4e56-be06-46cdd1d448f2"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Check Source Control Connector Configuration -> Get Workflow IRI",
+            "targetStep": "\/api\/3\/workflow_steps\/90d93b94-70dc-4d3e-8527-6e292bf92f81",
+            "sourceStep": "\/api\/3\/workflow_steps\/dd1ad8e0-ad8b-4272-9e4b-6c7d4acae82a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3974d8ef-72df-466c-82ad-cc62e4f0957c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Environment Type -> Find Source Control Setting Record",
+            "targetStep": "\/api\/3\/workflow_steps\/00b7753a-2a8a-4a26-a523-d6cf755da653",
+            "sourceStep": "\/api\/3\/workflow_steps\/38b861cb-bf5b-410b-b3ab-2a5a9cfa531f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "27d2e42c-2691-434d-ad0e-46767e41c994"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find CICD Global Variable -> Get Configured Connectors",
+            "targetStep": "\/api\/3\/workflow_steps\/765ad568-c4e7-4d73-b6b9-1bc04113b2a8",
+            "sourceStep": "\/api\/3\/workflow_steps\/9782af0e-07ee-4212-ab68-1b693d94ae65",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b48f61de-028c-444b-a225-b92405c4b46d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Setup Environments -> Check Setup Type",
+            "targetStep": "\/api\/3\/workflow_steps\/aeb19201-0669-4865-b146-997d2a252b8d",
+            "sourceStep": "\/api\/3\/workflow_steps\/19684900-c7eb-4486-a95c-7db378305209",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "331554d3-a39b-456f-9dcd-b5520357bebf"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Find Source Control Setting Record -> Update CICD Config Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/950dc53c-5846-4e1e-b965-b9ffc089dd01",
+            "sourceStep": "\/api\/3\/workflow_steps\/00b7753a-2a8a-4a26-a523-d6cf755da653",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ae388eba-02e6-4b04-85d7-511c434f27ba"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get CICD Config Global Variable -> Refine CICD Config Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/1bbf31ac-471e-49a9-9e7c-7b6aaf65a314",
+            "sourceStep": "\/api\/3\/workflow_steps\/1a140d91-aba9-4d17-9303-e26f91efedb1",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5183c80e-18e4-4db8-b929-726b1f555f5c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Key Store Record -> Is Upgrade",
+            "targetStep": "\/api\/3\/workflow_steps\/9d19fb34-9891-4a50-8bbf-a1a25924c2df",
+            "sourceStep": "\/api\/3\/workflow_steps\/e760d2ad-13c7-4f96-a2eb-a8aa89a9f1f9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "01203a36-ccba-490c-8eb6-c71d0f2f6896"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Connector -> Update CICD Env Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/47c8c19b-1d7b-46d2-b372-ec5326988a92",
+            "sourceStep": "\/api\/3\/workflow_steps\/765ad568-c4e7-4d73-b6b9-1bc04113b2a8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a219533d-a498-4c45-bffa-2c273fe49f42"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Server URL -> Map CICD Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/1843b9f1-f61d-4ad5-a576-c13662ff1352",
+            "sourceStep": "\/api\/3\/workflow_steps\/928eab73-30b8-47c4-8038-dab7cab8a416",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "06362971-62d2-4a2a-80e1-d99b8ef7ed76"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Workflow IRI -> Get Source Control Server URL",
+            "targetStep": "\/api\/3\/workflow_steps\/928eab73-30b8-47c4-8038-dab7cab8a416",
+            "sourceStep": "\/api\/3\/workflow_steps\/90d93b94-70dc-4d3e-8527-6e292bf92f81",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "dc5c28a3-5fb4-4378-8b96-c0bec11dee05"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upgrade -> Get CICD Config Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/1a140d91-aba9-4d17-9303-e26f91efedb1",
+            "sourceStep": "\/api\/3\/workflow_steps\/9d19fb34-9891-4a50-8bbf-a1a25924c2df",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "10afa703-c059-4575-9e71-57d915cf0c26"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Upgrade -> No Operation",
+            "targetStep": "\/api\/3\/workflow_steps\/8995caa1-2b81-4866-810d-11078ffcc626",
+            "sourceStep": "\/api\/3\/workflow_steps\/9d19fb34-9891-4a50-8bbf-a1a25924c2df",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "956e41b4-eb79-4864-a3d7-c901167cd06e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Map CICD Configuration -> Environment Type",
+            "targetStep": "\/api\/3\/workflow_steps\/38b861cb-bf5b-410b-b3ab-2a5a9cfa531f",
+            "sourceStep": "\/api\/3\/workflow_steps\/1843b9f1-f61d-4ad5-a576-c13662ff1352",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6a938fda-e4b1-4746-a6e1-8c4f5f62ac39"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Refine CICD Config Global Variable -> Check Source Control Connector Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/dd1ad8e0-ad8b-4272-9e4b-6c7d4acae82a",
+            "sourceStep": "\/api\/3\/workflow_steps\/1bbf31ac-471e-49a9-9e7c-7b6aaf65a314",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e0dc71e1-5d55-4360-b7ca-3bbd3a9626c0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Refine CICD Config Global Variable -> Find Setup Environments",
+            "targetStep": "\/api\/3\/workflow_steps\/19684900-c7eb-4486-a95c-7db378305209",
+            "sourceStep": "\/api\/3\/workflow_steps\/1bbf31ac-471e-49a9-9e7c-7b6aaf65a314",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e3190467-a9d7-4453-bdbb-6fcbe71fdf6b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Get Key Store Record",
+            "targetStep": "\/api\/3\/workflow_steps\/e760d2ad-13c7-4f96-a2eb-a8aa89a9f1f9",
+            "sourceStep": "\/api\/3\/workflow_steps\/0af508fb-a31f-4a3d-9e9d-e60986a02f77",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "69218709-ba7c-41d3-9b8c-35b40f85c3ef"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Both Dev Environment -> Find CICD Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/9782af0e-07ee-4212-ab68-1b693d94ae65",
+            "sourceStep": "\/api\/3\/workflow_steps\/c702091d-605a-445a-90be-e34f25fb5387",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0dad0ddd-3d98-422c-bddb-f40f5832fe0f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update CICD Config Settings -> Find CICD Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/9782af0e-07ee-4212-ab68-1b693d94ae65",
+            "sourceStep": "\/api\/3\/workflow_steps\/950dc53c-5846-4e1e-b965-b9ffc089dd01",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "11713189-1655-400d-9a34-c6c99267410d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update CICD Env Global Variable -> Delete CICD Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/8d0d1e36-61e8-498a-a83e-dcc8ba5ed71f",
+            "sourceStep": "\/api\/3\/workflow_steps\/1a32eb89-15c9-4e73-adde-8bcd0969ae3b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "8fe91dba-f177-4569-b119-c42b673a4571"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update CICD Env Global Variable -> Update CICD Env Global Variable1",
+            "targetStep": "\/api\/3\/workflow_steps\/1a32eb89-15c9-4e73-adde-8bcd0969ae3b",
+            "sourceStep": "\/api\/3\/workflow_steps\/47c8c19b-1d7b-46d2-b372-ec5326988a92",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "13afedc4-89af-40c7-863e-264065385bb4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Dev Environment -> Update Dev Prod Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/17f8bff1-ac4d-4e8f-9803-9ef28aedc1b8",
+            "sourceStep": "\/api\/3\/workflow_steps\/a055452e-e454-4d5d-8cf4-00554045dfa8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "7af9dc79-ad79-47a2-ba5d-e5069e67346b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Dev Prod Environment -> Find CICD Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/9782af0e-07ee-4212-ab68-1b693d94ae65",
+            "sourceStep": "\/api\/3\/workflow_steps\/17f8bff1-ac4d-4e8f-9803-9ef28aedc1b8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9294a724-829c-460e-a19a-d91a1186ef1c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Prod Dev Environment -> Find CICD Global Variable",
+            "targetStep": "\/api\/3\/workflow_steps\/9782af0e-07ee-4212-ab68-1b693d94ae65",
+            "sourceStep": "\/api\/3\/workflow_steps\/f4466f30-3cde-4896-b31b-577cc41cc688",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3d391299-bd2b-465b-a121-f852be6ebb20"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Prod Environment -> Update Dev Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/f4466f30-3cde-4896-b31b-577cc41cc688",
+            "sourceStep": "\/api\/3\/workflow_steps\/63c46ec5-30e3-4cd5-8202-3d51935ccfcd",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "1fa3c7ff-9151-4c17-9ba6-69e63731a16d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Production Environment -> Update Development Environment",
+            "targetStep": "\/api\/3\/workflow_steps\/c702091d-605a-445a-90be-e34f25fb5387",
+            "sourceStep": "\/api\/3\/workflow_steps\/e7dd7c3b-9c7c-45f2-a1b4-80f80916b10e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "fb1cdaf5-18a3-4014-b756-d3bd498b350d"
+        }
+    ],
+    "groups": [],
+    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "playbookOrigin": "\/api\/3\/picklists\/15c1e8c9-22bf-4e66-8fbb-0a502d4a4a3f",
+    "isEditable": true,
+    "uuid": "83cfe2a7-5149-4b5e-906d-64310f33b8e7",
+    "owners": [],
+    "isPrivate": false,
+    "deletedAt": null,
+    "recordTags": [
+        "cicd-utils",
+        "PostInstall"
+    ]
+}

--- a/postInstall/workflow/collection.metadata.json
+++ b/postInstall/workflow/collection.metadata.json
@@ -1,0 +1,11 @@
+{
+    "@context": "\/api\/3\/contexts\/WorkflowCollection",
+    "@type": "WorkflowCollection",
+    "name": "Post-Install",
+    "description": null,
+    "visible": true,
+    "image": null,
+    "uuid": "d4665980-9836-4181-9dc1-84dc61bfc696",
+    "deletedAt": null,
+    "recordTags": []
+}


### PR DESCRIPTION
- 1205649 | Added CICD upgrade script
   - Handle `Setup`, `Production`, `Development` tab visibility 
   - Removed `cicd_config` global variable and added its value in to `Source Control Settings` record under the `Configuration Parameters` field.
   - `Documentation Impact`:
      - Before upgrade `CICD Setup Production/Development` task should be completed 
      - After upgrade execute `CICD Configuration Wizard` to fetch the new pluggable source control actions playbooks
      - Removed `cicd_config` global variable and added its value in to `Source Control Settings` record under the `Configuration Parameters` field.