### PR TITLE
BugFixes

### DIFF
--- a/modules/change_management/mmd.json
+++ b/modules/change_management/mmd.json
@@ -124,7 +124,7 @@
                     "logic": "AND",
                     "filters": [
                         {
-                            "field": "commitStatus",
+                            "field": "lastCommitID",
                             "operator": "isnull",
                             "_operator": "isnull",
                             "value": "false",

--- a/playbooks/02 - Use Case - CICD/Evaluate Git Sync Drift.json
+++ b/playbooks/02 - Use Case - CICD/Evaluate Git Sync Drift.json
@@ -9,39 +9,12 @@
     "debug": false,
     "singleRecordExecution": false,
     "remoteExecutableFlag": false,
-    "parameters": [
-        "cr_iri",
-        "lastCommitID",
-        "previousCommitID",
-        "org_name",
-        "repo_name",
-        "connector_config_id"
-    ],
+    "parameters": [],
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/4c58fed3-9e16-451a-9528-0be2b71acda4",
     "versions": [],
     "triggerStep": "\/api\/3\/workflow_steps\/c813cbb3-191e-4a0b-929f-5511c150947b",
     "steps": [
-        {
-            "@type": "WorkflowStep",
-            "name": "Check Source Control Connector Configuration",
-            "description": null,
-            "arguments": {
-                "when": "{{vars.input.params['connector_config_id'] | length == 0}}",
-                "arguments": [],
-                "apply_async": false,
-                "step_variables": [],
-                "pass_parent_env": false,
-                "pass_input_record": true,
-                "workflowReference": "\/api\/3\/workflows\/dd654cd4-923f-4c20-837c-279669c2fa82"
-            },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "group": null,
-            "uuid": "162fb2f9-c370-4559-bc37-025ea8ad7fd3"
-        },
         {
             "@type": "WorkflowStep",
             "name": "Configuration",
@@ -51,11 +24,10 @@
                 "cicd_env": "{{globalVars.cicd_env}}",
                 "cicd_config": "{% set config_params = {} %}{% set prod_config = {} %}{% set dev_config = {} %}{% for item in vars.steps.Find_Source_Control_Settings %}{% if item.configurationParameters is not none %}{% if item.environment.itemValue == 'Production' %}{% set _ = prod_config.update(item.configurationParameters) %}{% elif item.environment.itemValue == 'Development' %}{% set _ = dev_config.update(item.configurationParameters) %}{% endif %}{% endif %}\n{% endfor %}{% if prod_config and dev_config %}{% set _ = config_params.update(prod_config) %}{% elif prod_config %}{% set _ = config_params.update(prod_config) %}{% elif dev_config %}{% set _ = config_params.update(dev_config) %}{% else %}{% set _ = config_params.update({}) %}{% endif %}{{config_params}}",
                 "lastCommitID": "{{vars.input.records[0].lastCommitID or vars.input.params.lastCommitID or None}}",
-                "previousCommitID": "{{vars.previous.data.lastCommitID or vars.input.params.previousCommitID or None}}",
-                "connector_config_id": "{{vars.input.params['connector_config_id'] or vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}"
+                "previousCommitID": "{{vars.previous.data.lastCommitID or vars.input.params.previousCommitID or None}}"
             },
             "status": null,
-            "top": "570",
+            "top": "435",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
@@ -68,7 +40,7 @@
             "arguments": {
                 "arguments": {
                     "get_commit_params": "{\n\"org_name\": \"{{vars.cicd_config.organizationName}}\",\n\"repo_name\": \"{{vars.cicd_config.contentRepoName}}\",\n\"base\": \"{{vars.lastCommitID}}\",\n\"head\": \"{{vars.previousCommitID}}\"\n}",
-                    "connector_config_id": "{{vars.connector_config_id}}"
+                    "connector_config_id": "{{vars.current_user_source_control_connector_config_id}}"
                 },
                 "apply_async": false,
                 "step_variables": [],
@@ -77,7 +49,7 @@
                 "workflowReference": "{{vars.cicd_env[\"source_control_playbooks\"][\"GetCommitComparison\"][\"@id\"]}}"
             },
             "status": null,
-            "top": "840",
+            "top": "1380",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
             "group": null,
@@ -128,11 +100,98 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "435",
+            "top": "300",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "bcf4a52c-9cdb-4e21-afe3-5bd5401b7054"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get All Source Control Mapped Users",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/auth\/query\/users",
+                    "body": "{ \"users\": {{vars.userIds}} }",
+                    "method": "POST"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "logged_in_user": "{{(vars.steps.Get_All_Source_Control_Mapped_Users.data.usersresp | json_query(\"[?is_logged_in == `true`].uuid\"))[0]}}"
+                }
+            },
+            "status": null,
+            "top": "705",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "451c00ed-f6ec-432b-b6e5-907d72738def"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get All Users Details",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/3\/people?$limit=5000&$orderby=%2Bfirstname,%2Blastname,-modifyDate",
+                    "body": "",
+                    "method": "GET"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": {
+                    "userIds": "{{ vars.steps.Get_All_Users_Details.data['hydra:member'] | json_query(\"[?sourceControlUsername != `null` && csActive == `true`].userId\") }}"
+                }
+            },
+            "status": null,
+            "top": "570",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "4f5fdedf-c561-421a-89cb-b0015fb39db4"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Current User Configuration",
+            "description": null,
+            "arguments": {
+                "current_user_source_control_connector_config_id": "{% set ns = namespace(result = none) %}{% for item in vars.steps.Get_Source_Control_Connector_Configurations.data.configuration %}{% if item.config.username == vars.logged_in_user_sc_name %}{% set ns.result = item.config_id %}{% endif %}{% endfor %}{{ ns.result | tojson }}"
+            },
+            "status": null,
+            "top": "1110",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "2df009ba-0589-4fcf-a92a-a7400540c18d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Connector Configurations",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "iri": "\/api\/integration\/connectors\/{{vars.cicd_env[\"source_control\"][\"name\"]}}\/{{vars.cicd_env[\"source_control\"][\"version\"]}}\/?format=json",
+                    "body": "",
+                    "method": "POST"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "make_cyops_request",
+                "operationTitle": "FSR: Make FortiSOAR API Call",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "840",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "217f2e09-f18b-4cf4-a02d-674d41486598"
         },
         {
             "@type": "WorkflowStep",
@@ -156,7 +215,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "1245",
             "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -170,9 +229,9 @@
                 "conditions": [
                     {
                         "option": "No",
-                        "step_iri": "\/api\/3\/workflow_steps\/162fb2f9-c370-4559-bc37-025ea8ad7fd3",
+                        "step_iri": "\/api\/3\/workflow_steps\/bcf4a52c-9cdb-4e21-afe3-5bd5401b7054",
                         "condition": "{{ vars.input.records[0].lastCommitID | length > 0 }}",
-                        "step_name": "Check Source Control Connector Configuration"
+                        "step_name": "Find Source Control Settings"
                     },
                     {
                         "option": "Yes",
@@ -189,6 +248,20 @@
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "034908d6-3d95-43c3-9951-6db84f732ad3"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Logged in User Details",
+            "description": null,
+            "arguments": {
+                "logged_in_user_sc_name": "{% set ns = namespace(result = none) %}{% for user in vars.steps.Get_All_Users_Details.data[\"hydra:member\"] %}{% if user.userId == vars.logged_in_user %}{% set ns.result = user.sourceControlUsername %}{% endif %}{% endfor %}{{ ns.result | tojson }}"
+            },
+            "status": null,
+            "top": "975",
+            "left": "300",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "b684735e-adb4-416f-aa6a-9a24753c0570"
         },
         {
             "@type": "WorkflowStep",
@@ -222,7 +295,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
@@ -306,7 +379,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1515",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -316,23 +389,13 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Check Source Control Connector Configuration -> Find Source Control Settings",
-            "targetStep": "\/api\/3\/workflow_steps\/bcf4a52c-9cdb-4e21-afe3-5bd5401b7054",
-            "sourceStep": "\/api\/3\/workflow_steps\/162fb2f9-c370-4559-bc37-025ea8ad7fd3",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "b96fe69a-6e34-46a1-8448-69599a1fed35"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Configuration -> Is Last Commit ID Present",
-            "targetStep": "\/api\/3\/workflow_steps\/74b0f40e-d013-4183-9c58-5aa3ab8597f6",
+            "name": "Configuration -> Get All Users Details",
+            "targetStep": "\/api\/3\/workflow_steps\/4f5fdedf-c561-421a-89cb-b0015fb39db4",
             "sourceStep": "\/api\/3\/workflow_steps\/8b0637f2-0293-4cae-b468-1566a8b17b1c",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "195e96c0-49e1-4ca2-b522-595845856159"
+            "uuid": "3837deb1-28f6-4161-b1b1-8f68f7b704f5"
         },
         {
             "@type": "WorkflowRoute",
@@ -356,6 +419,46 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Get All Source Control Mapped Users -> Get Source Control Connector Configurations",
+            "targetStep": "\/api\/3\/workflow_steps\/217f2e09-f18b-4cf4-a02d-674d41486598",
+            "sourceStep": "\/api\/3\/workflow_steps\/451c00ed-f6ec-432b-b6e5-907d72738def",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "628e9b58-7028-4d4d-9631-19fe3915de2f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get All Users Details -> Copy of Get All Users Details",
+            "targetStep": "\/api\/3\/workflow_steps\/451c00ed-f6ec-432b-b6e5-907d72738def",
+            "sourceStep": "\/api\/3\/workflow_steps\/4f5fdedf-c561-421a-89cb-b0015fb39db4",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c000502e-d591-4cf6-ab2b-8e6e752e62a3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Current User Configuration -> Is Last Commit ID Present",
+            "targetStep": "\/api\/3\/workflow_steps\/74b0f40e-d013-4183-9c58-5aa3ab8597f6",
+            "sourceStep": "\/api\/3\/workflow_steps\/2df009ba-0589-4fcf-a92a-a7400540c18d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a050d51e-0a0a-462b-8739-1af1af04048d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Connector Configurations -> Loggedin User Details",
+            "targetStep": "\/api\/3\/workflow_steps\/b684735e-adb4-416f-aa6a-9a24753c0570",
+            "sourceStep": "\/api\/3\/workflow_steps\/217f2e09-f18b-4cf4-a02d-674d41486598",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c1f088b3-52c0-420a-b8ab-8e45743f25f5"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Is Last Commit ID Present -> Fetch Commit Comparison",
             "targetStep": "\/api\/3\/workflow_steps\/805ac11c-d049-4494-af2e-c69070685c3c",
             "sourceStep": "\/api\/3\/workflow_steps\/74b0f40e-d013-4183-9c58-5aa3ab8597f6",
@@ -376,13 +479,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Last Commit Null -> Check Source Control Connector Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/162fb2f9-c370-4559-bc37-025ea8ad7fd3",
+            "name": "Is Last Commit Null -> Find Source Control Settings",
+            "targetStep": "\/api\/3\/workflow_steps\/bcf4a52c-9cdb-4e21-afe3-5bd5401b7054",
             "sourceStep": "\/api\/3\/workflow_steps\/034908d6-3d95-43c3-9951-6db84f732ad3",
             "label": "No",
             "isExecuted": false,
             "group": null,
-            "uuid": "e38f9693-fa90-4149-b45f-6760aebddcfe"
+            "uuid": "21f9e799-9dc4-4f74-8715-2b6e6d0f33ad"
         },
         {
             "@type": "WorkflowRoute",
@@ -396,13 +499,23 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Loggedin User Details -> Get Current User Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/2df009ba-0589-4fcf-a92a-a7400540c18d",
+            "sourceStep": "\/api\/3\/workflow_steps\/b684735e-adb4-416f-aa6a-9a24753c0570",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a4dc7fa8-ea65-49d6-bee9-5ac1b50ee24c"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Is Last Commit Null",
             "targetStep": "\/api\/3\/workflow_steps\/034908d6-3d95-43c3-9951-6db84f732ad3",
             "sourceStep": "\/api\/3\/workflow_steps\/c813cbb3-191e-4a0b-929f-5511c150947b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "46f52087-26e2-484c-a201-173ad97c801a"
+            "uuid": "97740b29-4a27-4cd3-9921-a8169415340f"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
+++ b/playbooks/02 - Use Case - CICD/Pull Latest Content from Source Control.json
@@ -435,7 +435,7 @@
             "name": "Get Latest Commit",
             "description": null,
             "arguments": {
-                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
+                "when": "{{vars.repo_name == vars.cicd_config.contentRepoName}}",
                 "arguments": {
                     "get_commit_params": "{\n\"org_name\": \"{{vars.org_name}}\",\n\"repo_name\": \"{{vars.repo_name}}\",\n\"commit_ref\": \"{{vars.base_branch_name}}\",\n\"repo_type\": \"Organization\"\n}",
                     "connector_config_id": "{{vars.steps.Check_Source_Control_Connector_Configuration['config_id']}}"
@@ -858,16 +858,7 @@
             "name": "Update Deployed Details",
             "description": null,
             "arguments": {
-                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p>Applying the latest content from the {{vars.repo_name}} repository<\/p>",
-                    "records": "{{vars.steps.Find_Apply_Latest_Changes_Record | json_query(\"[*][\\\"@id\\\"][]\")}}",
-                    "parentstepid": "\/api\/3\/workflow_steps\/a5c3262e-440b-4950-82bc-ad5f39e9bb93"
-                },
+                "when": "{{vars.repo_name == vars.cicd_config.contentRepoName}}",
                 "for_each": {
                     "item": "{{vars.steps.Find_Apply_Latest_Changes_Record}}",
                     "__bulk": true,
@@ -876,7 +867,7 @@
                     "batch_size": 100
                 },
                 "resource": {
-                    "commitStatus": "<h5 class=\"margin-top-negative-1\" style=\"color: #28a745;\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
+                    "commitStatus": "<h5 style=\"color: #28a745;\" class=\"margin-top-negative-1\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
                     "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}",
                     "lastBuildDeployedOn": "{%if vars.repo_name == vars.cicd_config.contentRepoName %}{{arrow.utcnow().int_timestamp}}{%else%}{{vars.input.records[0].lastBuildDeployedOn}}{%endif%}"
                 },
@@ -891,7 +882,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2160",
+            "top": "2040",
             "left": "100",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -902,6 +893,14 @@
             "name": "Update Status",
             "description": null,
             "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p>Applying the latest content from the {{vars.repo_name}} repository<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "resource": {
                     "status": "\/api\/3\/picklists\/cc6dc0fe-4a49-44e7-af30-8a0fbeacd293"
                 },
@@ -1004,7 +1003,7 @@
                 }
             },
             "status": null,
-            "top": "2040",
+            "top": "2160",
             "left": "100",
             "stepType": "\/api\/3\/workflow_step_types\/6832e556-b9c7-497a-babe-feda3bd27dbf",
             "group": null,
@@ -1204,13 +1203,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Import FortiSOAR Template -> Wait for Publish",
-            "targetStep": "\/api\/3\/workflow_steps\/2f0328bd-2b74-427e-b2e8-099ab6f4edbf",
+            "name": "Import FortiSOAR Template -> Update Deployed Details",
+            "targetStep": "\/api\/3\/workflow_steps\/e343e5e7-c917-4e1a-bd82-53a3d2859c50",
             "sourceStep": "\/api\/3\/workflow_steps\/4b66de3f-03f2-4cfa-bfbc-00453548e2a4",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "dbbf9d04-d710-4bd7-b3b7-b60a941dfe17"
+            "uuid": "5d03e883-2746-4426-a186-b2b488121ed6"
         },
         {
             "@type": "WorkflowRoute",
@@ -1304,13 +1303,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Deployed Date -> Create Comment",
-            "targetStep": "\/api\/3\/workflow_steps\/f183e6b1-7bc4-4fa1-bbe5-c78d383d64b0",
+            "name": "Update Deployed Details -> Wait for Publish",
+            "targetStep": "\/api\/3\/workflow_steps\/2f0328bd-2b74-427e-b2e8-099ab6f4edbf",
             "sourceStep": "\/api\/3\/workflow_steps\/e343e5e7-c917-4e1a-bd82-53a3d2859c50",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c38028f2-fdeb-4627-ba88-89a8a36eb3dd"
+            "uuid": "7698070f-9e2d-4807-841b-8f8ab2cfed54"
         },
         {
             "@type": "WorkflowRoute",
@@ -1324,13 +1323,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Wait for Publish -> Update Deployed Date",
-            "targetStep": "\/api\/3\/workflow_steps\/e343e5e7-c917-4e1a-bd82-53a3d2859c50",
+            "name": "Wait for Publish -> Create Comment",
+            "targetStep": "\/api\/3\/workflow_steps\/f183e6b1-7bc4-4fa1-bbe5-c78d383d64b0",
             "sourceStep": "\/api\/3\/workflow_steps\/2f0328bd-2b74-427e-b2e8-099ab6f4edbf",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "7442f705-5510-494a-80e3-25cf41e32524"
+            "uuid": "0966c1ef-7480-4648-8e19-e840abdab85d"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
+++ b/playbooks/02 - Use Case - CICD/Retrieve Source Control Sync Status.json
@@ -17,32 +17,6 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Check Environment Sync Status",
-            "description": null,
-            "arguments": {
-                "arguments": {
-                    "cr_iri": "{{vars.steps.Find_Last_Commit_ID[0]['@id']}}",
-                    "org_name": "{{vars.cicd_config.organizationName}}",
-                    "repo_name": "{{vars.cicd_config.contentRepoName}}",
-                    "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}",
-                    "previousCommitID": "{{vars.steps.Find_Last_Commit_ID[0].lastCommitID}}",
-                    "connector_config_id": "{{vars.config_id}}"
-                },
-                "apply_async": false,
-                "step_variables": [],
-                "pass_parent_env": false,
-                "pass_input_record": false,
-                "workflowReference": "\/api\/3\/workflows\/fce53c7e-778d-48aa-afb7-8f67830570ab"
-            },
-            "status": null,
-            "top": "1515",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
-            "group": null,
-            "uuid": "c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8"
-        },
-        {
-            "@type": "WorkflowStep",
             "name": "Configuration",
             "description": null,
             "arguments": {
@@ -221,9 +195,9 @@
                 "conditions": [
                     {
                         "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8",
+                        "step_iri": "\/api\/3\/workflow_steps\/bfbfc946-30f3-4ca8-8e06-87e9f6bc243a",
                         "condition": "{{ (vars.steps.Find_Last_Commit_ID[0].lastCommitID != None) and (vars.steps.Find_Last_Commit_ID[0].lastCommitID != vars.steps.Get_Latest_Commit.data.sha) }}",
-                        "step_name": "Check Environment Sync Status"
+                        "step_name": "Update Latest Commit"
                     },
                     {
                         "option": "No",
@@ -236,7 +210,7 @@
             },
             "status": null,
             "top": "1380",
-            "left": "475",
+            "left": "480",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "2dc6565e-de0b-4331-9d55-12a106ca3793"
@@ -351,6 +325,30 @@
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "668f019d-d72e-4249-8342-c6b671ae1cc6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Update Latest Commit",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}"
+                },
+                "operation": "Append",
+                "collection": "{{vars.steps.Find_Last_Commit_ID[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/change_management",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1520",
+            "left": "280",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "bfbfc946-30f3-4ca8-8e06-87e9f6bc243a"
         }
     ],
     "routes": [
@@ -416,16 +414,6 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Commit id Drift -> Check Environment Sync Status",
-            "targetStep": "\/api\/3\/workflow_steps\/c8cd31b8-8647-4e96-9b4f-1aa3fa816dc8",
-            "sourceStep": "\/api\/3\/workflow_steps\/2dc6565e-de0b-4331-9d55-12a106ca3793",
-            "label": "Yes",
-            "isExecuted": false,
-            "group": null,
-            "uuid": "31a6e645-2d3c-46a0-8d29-5862057f5640"
-        },
-        {
-            "@type": "WorkflowRoute",
             "name": "Is Commit id Drift -> No Operation",
             "targetStep": "\/api\/3\/workflow_steps\/72b152e3-8add-4aab-9454-eb429da57826",
             "sourceStep": "\/api\/3\/workflow_steps\/2dc6565e-de0b-4331-9d55-12a106ca3793",
@@ -433,6 +421,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "bad53682-d07b-4125-a943-9433a39cc544"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Commit ID Drift -> Update Latest Commit",
+            "targetStep": "\/api\/3\/workflow_steps\/bfbfc946-30f3-4ca8-8e06-87e9f6bc243a",
+            "sourceStep": "\/api\/3\/workflow_steps\/2dc6565e-de0b-4331-9d55-12a106ca3793",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3fb7118f-ff49-4505-8cd5-250c28607f1d"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
+++ b/playbooks/02 - Use Case - CICD/Setup CICD Environment.json
@@ -22,23 +22,24 @@
             "name": "Activate Source Control Sync Status Schedule",
             "description": null,
             "arguments": {
+                "when": "{{vars.cicd_config.env_config | length == 1 and vars.cicd_config.env_config[0].itemValue == \"Production\"}}",
                 "params": {
                     "iri": "\/api\/wf\/api\/scheduled\/{{vars.steps.Get_Source_Control_Sync_Status_Schedule_Details.data['hydra:member'][0].id}}\/?format=json",
                     "body": "{\n    \"id\": \"gAAAAABogL_f0z1Br_2VEIMqyq7kbg6BxCcPjgUkhluoH06hO1Zq-xwD97YR0rdjwJz_tGUS6YiT9_mFeJeS9JnOHcH_mFM5uQ==\",\n    \"crontab\": {\n        \"id\": 3,\n        \"minute\": \"0\",\n        \"hour\": \"*\/1\",\n        \"day_of_week\": \"*\",\n        \"day_of_month\": \"*\",\n        \"month_of_year\": \"*\",\n        \"timezone\": \"UTC\"\n    },\n    \"interval\": null,\n    \"name\": \"Ingest_Source-Control-Sync-Status(CICD)\",\n    \"task\": \"workflow.tasks.periodic_task\",\n    \"enabled\": true\n}",
                     "method": "PUT"
                 },
-                "version": "3.6.0",
+                "version": "3.5.0",
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",
                 "step_variables": []
             },
             "status": null,
-            "top": "1520",
-            "left": "480",
+            "top": "1650",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
-            "uuid": "7654b64e-acba-4cd9-a17f-5d473404c784"
+            "uuid": "6b92edaa-6008-45c7-838d-3bacd4a42601"
         },
         {
             "@type": "WorkflowStep",
@@ -68,8 +69,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "700",
-            "left": "480",
+            "top": "840",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "7aeabc30-3990-4b2f-933c-ca56a2c29028"
@@ -84,8 +85,8 @@
                 "source_control_operations": "{% set filtered = [] %}{% for item in ((vars.steps.Get_Source_Control_Playbooks.data['hydra:member'] | json_query(\"[?isActive==`true`].recordTags\")) | flatten(levels=1)) %}{% if '-' in item %}{% do filtered.append(item) %}{% endif %}{% endfor %}{{filtered}}"
             },
             "status": null,
-            "top": "440",
-            "left": "480",
+            "top": "570",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
             "uuid": "72d4a7bd-82d9-45ce-8092-de138c20189b"
@@ -106,8 +107,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1240",
-            "left": "480",
+            "top": "1380",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "813442f4-8ab0-4a86-9af4-515fb8dc8985"
@@ -135,11 +136,33 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "580",
-            "left": "480",
+            "top": "705",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
             "group": null,
             "uuid": "0aded246-f9d5-48f2-829c-37952fe60070"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Source Control Connector",
+            "description": null,
+            "arguments": {
+                "params": {
+                    "query": "{{{\n  \"__selectFields\": [\n    \"name\",\n    \"label\",\n    \"version\",\n    \"uuid\"\n  ],\n  \"logic\": \"AND\",\n  \"filters\": [\n    {\n      \"field\": \"type\",\n      \"operator\": \"in\",\n      \"value\": [\n        \"connector\"\n      ]\n    },\n    {\n      \"field\": \"installed\",\n      \"operator\": \"eq\",\n      \"value\": true\n    },\n    {\n      \"field\": \"name\",\n      \"operator\": \"eq\",\n      \"value\": vars.request.sourceControl.name\n    }\n  ]\n}}}",
+                    "resource": "solutionpacks"
+                },
+                "version": "3.7.0",
+                "connector": "cyops_utilities",
+                "operation": "query_cyops_resource",
+                "operationTitle": "FSR: Find Record",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
+            "group": null,
+            "uuid": "82f9efc8-1359-41db-a55c-7341edbb1d6d"
         },
         {
             "@type": "WorkflowStep",
@@ -147,19 +170,19 @@
             "description": null,
             "arguments": {
                 "params": {
-                    "iri": "\/api\/3\/workflow_collections?$limit=2147483647&$orderby=name&$relationships=true&__selectFields=fsr_primary,workflowCount&name=Sample - {{vars.request.sourceControl.label}} - {{vars.request.sourceControl.version}}",
+                    "iri": "\/api\/3\/workflow_collections?$limit=2147483647&$orderby=name&$relationships=true&__selectFields=fsr_primary,workflowCount&name=Sample - {{vars.steps.Get_Source_Control_Connector.data[0].label}} - {{vars.steps.Get_Source_Control_Connector.data[0].version}}",
                     "body": "",
                     "method": "GET"
                 },
-                "version": "3.6.0",
+                "version": "3.7.0",
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",
                 "step_variables": []
             },
             "status": null,
-            "top": "160",
-            "left": "480",
+            "top": "300",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "fc39f306-f324-47bc-a307-3d0bb2a2bbee"
@@ -181,8 +204,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "300",
-            "left": "480",
+            "top": "435",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "d5836224-b1bc-485b-b5d8-4f251df39d05"
@@ -192,23 +215,24 @@
             "name": "Get Source Control Sync Status Schedule Details",
             "description": null,
             "arguments": {
+                "when": "{{vars.cicd_config.env_config | length == 1 and vars.cicd_config.env_config[0].itemValue == \"Production\"}}",
                 "params": {
                     "iri": "\/api\/wf\/api\/scheduled\/?depth=2&format=json&limit=5000&ordering=-modified&task=workflow.tasks.periodic_task&name=Ingest_Source-Control-Sync-Status(CICD)",
                     "body": "",
                     "method": "GET"
                 },
-                "version": "3.6.0",
+                "version": "3.5.0",
                 "connector": "cyops_utilities",
                 "operation": "make_cyops_request",
                 "operationTitle": "FSR: Make FortiSOAR API Call",
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "480",
+            "top": "1515",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
-            "uuid": "71c4410e-c4d8-47b2-8387-775da6d096bc"
+            "uuid": "4377ca64-5178-4459-9a2c-87106e8575fe"
         },
         {
             "@type": "WorkflowStep",
@@ -233,8 +257,8 @@
                 }
             },
             "status": null,
-            "top": "1100",
-            "left": "480",
+            "top": "1245",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "b688e2d8-9214-4196-9952-5f623d8637eb"
@@ -268,8 +292,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "140",
+            "top": "975",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "09e37b88-4466-4104-87c4-a4c8b3640696"
@@ -303,8 +327,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "920",
-            "left": "480",
+            "top": "1110",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "990eb8db-3c12-4144-bcda-9ba15717e849"
@@ -338,7 +362,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "975",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -356,8 +380,8 @@
                 }
             },
             "status": null,
-            "top": "40",
-            "left": "480",
+            "top": "30",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
             "uuid": "e3243c1a-daf7-4bf1-901a-8cc380e797f2"
@@ -388,8 +412,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "980",
-            "left": "140",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "a84c99ad-f48e-405d-a1df-4100fc01f7a3"
@@ -420,7 +444,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "975",
+            "top": "1110",
             "left": "825",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -470,13 +494,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Create CICD Env Global Variable -> Get Investigate Outbreak Alerts Schedule Details",
-            "targetStep": "\/api\/3\/workflow_steps\/71c4410e-c4d8-47b2-8387-775da6d096bc",
+            "name": "Create CICD Env Global Variable -> Get Source Control Sync Status Schedule Details",
+            "targetStep": "\/api\/3\/workflow_steps\/4377ca64-5178-4459-9a2c-87106e8575fe",
             "sourceStep": "\/api\/3\/workflow_steps\/813442f4-8ab0-4a86-9af4-515fb8dc8985",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "28d72f0e-2e06-4f6a-bc67-a1fac7b0bcf4"
+            "uuid": "754ed009-02d1-4b5d-8755-96d78b17d74f"
         },
         {
             "@type": "WorkflowRoute",
@@ -490,13 +514,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Investigate Outbreak Alerts Schedule Details -> Activate Investigate Outbreak Alerts Schedule",
-            "targetStep": "\/api\/3\/workflow_steps\/7654b64e-acba-4cd9-a17f-5d473404c784",
-            "sourceStep": "\/api\/3\/workflow_steps\/71c4410e-c4d8-47b2-8387-775da6d096bc",
+            "name": "Get Source Control Connector -> Get Source Control Playbook Collection",
+            "targetStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
+            "sourceStep": "\/api\/3\/workflow_steps\/82f9efc8-1359-41db-a55c-7341edbb1d6d",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "366be41e-e487-46b0-87e2-91aa12bb6593"
+            "uuid": "2bf05d95-79b6-411c-9050-6a8176677e26"
         },
         {
             "@type": "WorkflowRoute",
@@ -517,6 +541,16 @@
             "isExecuted": false,
             "group": null,
             "uuid": "e346a6af-4d11-4d95-92dd-e7f355fb40cd"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Source Control Sync Status Schedule Details -> Activate Source Control Sync Status Schedule",
+            "targetStep": "\/api\/3\/workflow_steps\/6b92edaa-6008-45c7-838d-3bacd4a42601",
+            "sourceStep": "\/api\/3\/workflow_steps\/4377ca64-5178-4459-9a2c-87106e8575fe",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f0bf8b3a-4f4d-4550-bb14-05577bf55eb9"
         },
         {
             "@type": "WorkflowRoute",
@@ -560,13 +594,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get Source Control Playbook Collection",
-            "targetStep": "\/api\/3\/workflow_steps\/fc39f306-f324-47bc-a307-3d0bb2a2bbee",
+            "name": "Start -> Get Source Control Connector",
+            "targetStep": "\/api\/3\/workflow_steps\/82f9efc8-1359-41db-a55c-7341edbb1d6d",
             "sourceStep": "\/api\/3\/workflow_steps\/e3243c1a-daf7-4bf1-901a-8cc380e797f2",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "02911476-6c4c-4a4e-895b-e8fd33fcf8aa"
+            "uuid": "5984cc56-7017-4adf-a83f-f67d3461d538"
         },
         {
             "@type": "WorkflowRoute",

--- a/playbooks/02 - Use Case - CICD/Update Apply Latest Content Commit Details.json
+++ b/playbooks/02 - Use Case - CICD/Update Apply Latest Content Commit Details.json
@@ -48,7 +48,7 @@
                 },
                 "cicd_env": "{{globalVars.cicd_env}}",
                 "org_name": "{{vars.cicd_config.organizationName}}",
-                "repo_name": "{% if vars.steps.Select_Input_For_Prod_Env.input.selectRepositoryType == \"Prod Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% elif vars.steps.Select_Input_For_Dev_Env.input.selectRepositoryType == \"Dev Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}",
+                "repo_name": "{% if vars.request.selectedRepository == \"Production Settings\" %}{{vars.cicd_config.prodSettingsRepoName}}{% elif vars.request.selectedRepository == \"Development Settings\" %}{{vars.cicd_config.devSettingsRepoName}}{% else %}{{vars.cicd_config.contentRepoName}}{% endif %}",
                 "base_branch_name": "{{vars.cicd_config.baseBranch}}"
             },
             "status": null,
@@ -116,7 +116,7 @@
             "name": "Get Latest Commit",
             "description": null,
             "arguments": {
-                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
+                "when": "{{vars.repo_name == vars.cicd_config.contentRepoName}}",
                 "message": {
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -197,7 +197,7 @@
             "name": "Update Commit Details",
             "description": null,
             "arguments": {
-                "when": "{{vars.repo_name == \"fortisoar-prod-content\"}}",
+                "when": "{{vars.repo_name == vars.cicd_config.contentRepoName}}",
                 "resource": {
                     "commitStatus": "<h5 style=\"color: #28a745;\" class=\"margin-top-negative-1\">\u2705 Environment is Up-to-Date<\/h5>\n<p>No drift detected. The environment is fully synchronized with the latest production content.<\/p>",
                     "lastCommitID": "{{vars.steps.Get_Latest_Commit.data.sha}}",

--- a/playbooks/02 - Use Case - CICD/Update Development Source Control Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Update Development Source Control Configuration.json
@@ -13,14 +13,14 @@
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/4c58fed3-9e16-451a-9528-0be2b71acda4",
     "versions": [],
-    "triggerStep": "\/api\/3\/workflow_steps\/9ad6e38c-5eb0-48b0-ac2d-80aafa47e5e7",
+    "triggerStep": "\/api\/3\/workflow_steps\/466a53ac-6865-451b-b11a-d18e7f89cc2a",
     "steps": [
         {
             "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
-                "route": "a1b19f9d-2387-4ce8-acf2-ef23c2c249aa",
+                "route": "20e08bb4-bb13-4d43-bdb2-a289e60f0539",
                 "title": "Update Configuration Parameters",
                 "message": {
                     "tags": [],
@@ -56,33 +56,24 @@
                                 "_operator": "eq"
                             },
                             {
-                                "type": "array",
+                                "type": "object",
                                 "field": "environment",
-                                "value": {
-                                    "id": 465,
-                                    "@id": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
-                                    "icon": null,
-                                    "uuid": "d4ff078d-7692-4737-b45b-00990e949651",
-                                    "@type": "Picklist",
-                                    "color": "#11c1e5",
-                                    "display": "Development",
-                                    "listName": "\/api\/3\/picklist_names\/6b216e0d-c167-4cfd-a772-97fe1be0f52d",
-                                    "itemValue": "Development",
-                                    "importedBy": [],
-                                    "orderIndex": 0
-                                },
+                                "value": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
                                 "_value": {
-                                    "id": 465,
                                     "@id": "\/api\/3\/picklists\/d4ff078d-7692-4737-b45b-00990e949651",
-                                    "icon": null,
-                                    "uuid": "d4ff078d-7692-4737-b45b-00990e949651",
-                                    "@type": "Picklist",
-                                    "color": "#11c1e5",
                                     "display": "Development",
-                                    "listName": "\/api\/3\/picklist_names\/6b216e0d-c167-4cfd-a772-97fe1be0f52d",
-                                    "itemValue": "Development",
-                                    "importedBy": [],
-                                    "orderIndex": 0
+                                    "itemValue": "Development"
+                                },
+                                "operator": "eq"
+                            },
+                            {
+                                "type": "object",
+                                "field": "type",
+                                "value": "\/api\/3\/picklists\/dc57442c-3d52-43a0-aa19-ed2898e30ff7",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/dc57442c-3d52-43a0-aa19-ed2898e30ff7",
+                                    "display": "Development",
+                                    "itemValue": "Development"
                                 },
                                 "operator": "eq"
                             },
@@ -107,14 +98,14 @@
                     "messageVisible": true
                 },
                 "triggerOnReplicate": false,
-                "singleRecordExecution": false
+                "singleRecordExecution": true
             },
             "status": null,
             "top": "30",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
-            "uuid": "9ad6e38c-5eb0-48b0-ac2d-80aafa47e5e7"
+            "uuid": "466a53ac-6865-451b-b11a-d18e7f89cc2a"
         },
         {
             "@type": "WorkflowStep",
@@ -141,11 +132,11 @@
             "@type": "WorkflowRoute",
             "name": "Start -> Update Source Control Settings",
             "targetStep": "\/api\/3\/workflow_steps\/8463f750-1d32-4006-b7ba-810dc6b46c68",
-            "sourceStep": "\/api\/3\/workflow_steps\/9ad6e38c-5eb0-48b0-ac2d-80aafa47e5e7",
+            "sourceStep": "\/api\/3\/workflow_steps\/466a53ac-6865-451b-b11a-d18e7f89cc2a",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c7b24a2d-8e5c-4775-9f42-ce1727408b76"
+            "uuid": "59247a69-6351-4e50-a5aa-ce6ab285c5e3"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - CICD/Update Production Source Control Configuration.json
+++ b/playbooks/02 - Use Case - CICD/Update Production Source Control Configuration.json
@@ -13,14 +13,14 @@
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/4c58fed3-9e16-451a-9528-0be2b71acda4",
     "versions": [],
-    "triggerStep": "\/api\/3\/workflow_steps\/e0e325e1-207a-4966-b381-e27e750a1322",
+    "triggerStep": "\/api\/3\/workflow_steps\/7c376e01-4557-420a-9f55-55c4b0783c96",
     "steps": [
         {
             "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
-                "route": "469f07ff-f92e-42a0-8535-d7bd6fb7efa5",
+                "route": "9f297082-586b-42b8-b436-e860600c4de8",
                 "title": "Update Configuration Parameters",
                 "message": {
                     "tags": [],
@@ -56,33 +56,24 @@
                                 "_operator": "eq"
                             },
                             {
-                                "type": "array",
+                                "type": "object",
                                 "field": "environment",
-                                "value": {
-                                    "id": 466,
-                                    "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
-                                    "icon": null,
-                                    "uuid": "48b9f120-34bc-4884-b886-85e82321684b",
-                                    "@type": "Picklist",
-                                    "color": "#f75f0e",
-                                    "display": "Production",
-                                    "listName": "\/api\/3\/picklist_names\/6b216e0d-c167-4cfd-a772-97fe1be0f52d",
-                                    "itemValue": "Production",
-                                    "importedBy": [],
-                                    "orderIndex": 1
-                                },
+                                "value": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
                                 "_value": {
-                                    "id": 466,
                                     "@id": "\/api\/3\/picklists\/48b9f120-34bc-4884-b886-85e82321684b",
-                                    "icon": null,
-                                    "uuid": "48b9f120-34bc-4884-b886-85e82321684b",
-                                    "@type": "Picklist",
-                                    "color": "#f75f0e",
                                     "display": "Production",
-                                    "listName": "\/api\/3\/picklist_names\/6b216e0d-c167-4cfd-a772-97fe1be0f52d",
-                                    "itemValue": "Production",
-                                    "importedBy": [],
-                                    "orderIndex": 1
+                                    "itemValue": "Production"
+                                },
+                                "operator": "eq"
+                            },
+                            {
+                                "type": "object",
+                                "field": "type",
+                                "value": "\/api\/3\/picklists\/409b289f-33f5-423f-9174-24bc8628cc4a",
+                                "_value": {
+                                    "@id": "\/api\/3\/picklists\/409b289f-33f5-423f-9174-24bc8628cc4a",
+                                    "display": "Production",
+                                    "itemValue": "Production"
                                 },
                                 "operator": "eq"
                             },
@@ -107,14 +98,14 @@
                     "messageVisible": true
                 },
                 "triggerOnReplicate": false,
-                "singleRecordExecution": false
+                "singleRecordExecution": true
             },
             "status": null,
             "top": "30",
             "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/f414d039-bb0d-4e59-9c39-a8f1e880b18a",
             "group": null,
-            "uuid": "e0e325e1-207a-4966-b381-e27e750a1322"
+            "uuid": "7c376e01-4557-420a-9f55-55c4b0783c96"
         },
         {
             "@type": "WorkflowStep",
@@ -141,11 +132,11 @@
             "@type": "WorkflowRoute",
             "name": "Start -> Update Source Control Settings",
             "targetStep": "\/api\/3\/workflow_steps\/2b12f365-c112-4d37-9f4b-1dbd13cf9a03",
-            "sourceStep": "\/api\/3\/workflow_steps\/e0e325e1-207a-4966-b381-e27e750a1322",
+            "sourceStep": "\/api\/3\/workflow_steps\/7c376e01-4557-420a-9f55-55c4b0783c96",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "cf1650da-222d-48a2-8b45-40ddbceb2ea1"
+            "uuid": "c2b4a5f4-9600-4b19-a22f-bc3ca3ecc177"
         }
     ],
     "groups": [],


### PR DESCRIPTION
### PR 1212684 | "Commit Status" visibility on Source Control Settings page (Development Environment)
- **Root Cause (RCA):** Previously, the visibility condition relied on `commitStatus is not null`.
- **Solution:** Updated the condition to check `lastCommitID is not null` instead.

---

### PR 1211985 | "Update Production Source Control Configuration" button not visible
- **RCA:** The button was present in FSR 7.6.3 but missing in FSR 7.6.4.
- **Solution:**
  - Removed and re-added the `Start` step in both:
    - `Update Development Source Control Configuration`
    - `Update Production Source Control Configuration` playbooks.
  - Added an additional filter:
    - `Type = Production` for Production Environment.
    - `Type = Development` for Development Environment.

---

### PR 1212638 | Hardcoded 'fortisoar-prod-content' used in condition checks
- **Solution:** Removed hardcoded condition checks from the following playbooks:
  - `Pull Latest Content from Source Control`
  - `Update Apply Latest Content Commit Details`

---

### PR 1205148 | Commit Status not updating correctly in Production Environment
- **RCA:**
  - The `Evaluate Git Sync Drift` playbook is triggered automatically on update of `lastCommitID`.
  - As a result, the playbook runs as the system (not the logged-in user), leading to missing connector config ID tied to the user.
- **Solution:**
  - Modified logic to retrieve the logged-in user’s connector config ID explicitly to fetch the latest commit.
  - Removed the reference to `Evaluate Git Sync Drift` from `Retrieve Source Control Sync Status` playbook, since the former is auto-triggered on `lastCommitID` updates.

---

### PR 1212701 | Latest Source Control Connector version not updating post CICD SP upgrade
- **RCA:** The connector version was being fetched via API but didn’t retrieve the latest.
- **Solution:**
  - In the `Setup CICD Environment` playbook (executed post Configuration Wizard), enhanced the logic to:
    - Fetch the latest Source Control Connector Version using API.
    - Attempt to retrieve the latest Source Control pluggable playbooks.
